### PR TITLE
Bring Gradle build up to the latest updates

### DIFF
--- a/pipelines/clickstream_analytics_java/build.gradle
+++ b/pipelines/clickstream_analytics_java/build.gradle
@@ -21,7 +21,7 @@ ext {
   slf4jVersion = "1.7.36"
   junitVersion = "4.13.2"
   hamcrestVersion = "3.0"
-  googleJavaFormat = '1.17.0'
+  googleJavaFormat = '1.24.0'
   errorProneCoreVersion = '2.26.1'
 
 }
@@ -88,7 +88,7 @@ spotless {
     target '*.gradle', '*.md', '.gitignore'
     // define the steps to apply to those files
     trimTrailingWhitespace()
-    indentWithSpaces(2) // or spaces. Takes an integer argument if you don't like 4
+    leadingTabsToSpaces(2)
     endWithNewline()
   }
   java {

--- a/pipelines/etl_integration_java/build.gradle
+++ b/pipelines/etl_integration_java/build.gradle
@@ -38,7 +38,7 @@ ext {
   autoServiceVersion = '1.1.1'
   errorProneCoreVersion = '2.28.0'
 
-  googleJavaFormat = '1.17.0'
+  googleJavaFormat = '1.24.0'
   confluentRepoURL = "https://packages.confluent.io/maven"
 }
 
@@ -129,7 +129,7 @@ spotless {
 
     // define the steps to apply to those files
     trimTrailingWhitespace()
-    indentWithSpaces(2) // or spaces. Takes an integer argument if you don't like 4
+    leadingTabsToSpaces(2)
     endWithNewline()
   }
 


### PR DESCRIPTION
The maximum supported version for `google-java-format` with Java 11 is `1.24.0`, so we will pin to that version for the moment. These changes are updates to deprecated settings of the spotless plugin.