### PR TITLE
ci: pin GitHub Actions to full commit SHAs for zizmor security policy

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -27,13 +27,13 @@ jobs:
         shell: bash
     steps:
       - name: Checkout
-        uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: "Terraform:\n  - 'terraform/**'     \n"
       - name: Setup Terraform
-        uses: hashicorp/setup-terraform@v4
+        uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: Terraform Init
         working-directory: terraform
         run: |
@@ -65,13 +65,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: "Pipelines:\n  - 'pipelines/**'     \n"
       - name: Set up JDK 25
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@b6effb05e454b25005698d916606bdc6ffcbf961 # v5.7.0
         with:
           java-version: '25'
           distribution: 'temurin'
@@ -106,13 +106,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: "Pipelines:\n  - 'pipelines/**'     \n"
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       - name: Install pylint
@@ -146,13 +146,13 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
-      - uses: dorny/paths-filter@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
           filters: "Pipelines:\n  - 'pipelines/**'     \n"
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       - name: Install pipenv
@@ -192,8 +192,8 @@ jobs:
       run:
         shell: bash
     steps:
-      - uses: actions/checkout@v7
-      - uses: docker/setup-buildx-action@v4
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
       - name: Docker builds
         working-directory: pipelines
         run: |


### PR DESCRIPTION
## Description
This PR pins all GitHub Actions references in `.github/workflows/pull_request.yml` to full 40-character commit SHAs with trailing version comments (including `actions/setup-python` to `v7.0.0`).

This resolves the mandatory `zizmor/unpinned-uses` security scan errors that were blocking PR CI checks.

### Pinned Actions
- `actions/checkout`: `3d3c42e5aac5ba805825da76410c181273ba90b1` (# v7.0.1)
- `dorny/paths-filter`: `ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d` (# v4.0.3)
- `hashicorp/setup-terraform`: `dfe3c3f87815947d99a8997f908cb6525fc44e9e` (# v4.0.1)
- `actions/setup-java`: `b6effb05e454b25005698d916606bdc6ffcbf961` (# v5.7.0)
- `actions/setup-python`: `5fda3b95a4ea91299a34e894583c3862153e4b97` (# v7.0.0)
- `docker/setup-buildx-action`: `37fe631027851001ddb9b187196cc803df7f5f0e` (# v4.3.0)
