### PR TITLE
fix(pipelines): update keras_nlp to 0.31.1 and tensorflow to 2.20.0

### DIFF
--- a/pipelines/anomaly_detection/requirements-dev.txt
+++ b/pipelines/anomaly_detection/requirements-dev.txt
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-tensorflow==2.18.0
+tensorflow==2.20.0

--- a/pipelines/anomaly_detection/requirements.txt
+++ b/pipelines/anomaly_detection/requirements.txt
@@ -13,6 +13,6 @@
 #  limitations under the License.
 
 apache-beam[gcp]==2.75.0
-keras_nlp==0.29.1
+keras_nlp==0.31.1
 keras==3.15.1
 protobuf==5.29.6

--- a/pipelines/ml_ai_python/ml_ai_pipeline/model_handlers.py
+++ b/pipelines/ml_ai_python/ml_ai_pipeline/model_handlers.py
@@ -19,7 +19,7 @@ from typing import Sequence, Optional, Any, Iterable
 
 import keras_nlp
 from apache_beam.ml.inference.base import ModelHandler, PredictionResult
-from keras_nlp.src.models import GemmaCausalLM
+from keras_nlp.models import GemmaCausalLM
 
 
 class GemmaModelHandler(ModelHandler[str, PredictionResult, GemmaCausalLM]):

--- a/pipelines/ml_ai_python/requirements-dev.txt
+++ b/pipelines/ml_ai_python/requirements-dev.txt
@@ -12,4 +12,4 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-tensorflow==2.18.0
+tensorflow==2.20.0

--- a/pipelines/ml_ai_python/requirements.txt
+++ b/pipelines/ml_ai_python/requirements.txt
@@ -13,6 +13,6 @@
 #  limitations under the License.
 
 apache-beam[gcp]==2.75.0
-keras_nlp==0.29.1
+keras_nlp==0.31.1
 keras==3.15.1
 protobuf==5.29.6


### PR DESCRIPTION
## Summary

This PR resolves the dependency resolution failure seen in #211 by upgrading `keras_nlp` and aligning `tensorflow` in development requirements, alongside fixing the public import path for `GemmaCausalLM`.

### Changes
1. **Dependency updates**:
   - Updated `keras_nlp` to `0.31.1` in `pipelines/anomaly_detection/requirements.txt` and `pipelines/ml_ai_python/requirements.txt`.
   - Updated `tensorflow` to `2.20.0` in `pipelines/anomaly_detection/requirements-dev.txt` and `pipelines/ml_ai_python/requirements-dev.txt` to resolve the transitive dependency requirement from `keras-hub` / `tensorflow-text`.
2. **Public API Import Fix**:
   - Fixed `pipelines/ml_ai_python/ml_ai_pipeline/model_handlers.py` to import `GemmaCausalLM` from the public `keras_nlp.models` module rather than internal `keras_nlp.src.models` which changed in 0.31.1.

Closes #211