### PR TITLE
refactor(terraform): revamp GenAI & ML infrastructure to lightweight application-level IaC

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -23,7 +23,7 @@ dataflow-solution-guides/
 │   └── Log_replication.md    # Real-time log replication into Splunk
 │
 ├── terraform/                # Infrastructure-as-Code using Google Cloud Foundation Fabric
-│   ├── ml_ai/                # GPU quotas, VPC, GCS bucket, Pub/Sub topics/subscriptions
+│   ├── ml_ai/                # Pub/Sub topics, Artifact Registry, GCS bucket, Service Account
 │   ├── etl_integration/      # Spanner instance/database/change stream, BigQuery, Service Account
 │   ├── cdp/                  # Pub/Sub topics, BigQuery dataset/tables, VPC
 │   ├── anomaly_detection/    # Pub/Sub, BigQuery, Vertex AI endpoints, VPC

--- a/pipelines/ml_ai_python/Dockerfile
+++ b/pipelines/ml_ai_python/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --upgrade --no-cache-dir pip \
   && pip install --no-cache-dir -e .
 
 # Copy files from official SDK image, including script/dependencies.
-COPY --from=apache/beam_python3.11_sdk:2.76.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.11_sdk:2.75.0 /opt/apache/beam /opt/apache/beam
 
 COPY gemma_2B gemma_2B
 

--- a/pipelines/ml_ai_python/README.md
+++ b/pipelines/ml_ai_python/README.md
@@ -83,6 +83,18 @@ contain the Gemma model, and all the required dependencies:
 This will create a Cloud Build job that can take a few minutes to complete. Once it completes, you
 can trigger the pipeline with the following:
 
+> [!IMPORTANT]
+> **Python Version Matching:**
+> When submitting the pipeline using `DirectRunner` or `DataflowRunner`, ensure that the Python minor version in your local submission environment matches the Python version in the custom worker container image (**Python 3.11**). If a different version (such as Python 3.12 or 3.13) is used at submission time, Apache Beam's runtime descriptor verification and object deserialization on the worker will fail with a `RuntimeError: Pipeline construction environment and pipeline runtime environment are not compatible`.
+>
+> You can create a matching virtual environment using `uv` or `venv`:
+> ```sh
+> uv python install 3.11
+> uv venv .venv --python 3.11
+> source .venv/bin/activate
+> pip install -r requirements.txt -e .
+> ```
+
 ```sh
 ./scripts/02_run_dataflow.sh
 ```

--- a/pipelines/ml_ai_python/README.md
+++ b/pipelines/ml_ai_python/README.md
@@ -25,14 +25,14 @@ following stages:
 
 ## Gemma model
 
-The model needs to be uploaded to GCS in a directory named `gemma_2B` in the bucket created by
-Terraform (same name as project id).
+The model needs to be uploaded to GCS in a directory named `gemma_2B` in the bucket configured in
+Terraform (by default, `gs://<YOUR_BUCKET_OR_PROJECT_ID>/gemma_2B`).
 
 For that, please first [download the Gemma model from Kaggle](https://www.kaggle.com/models/google/gemma),
-uncompress it and then uploaded it with a command similar to this one:
+uncompress it and then upload it with a command similar to this one:
 
 ```sh
-gcloud storage cp -r LOCAL_DIRECTORY gs://<YOUR PROJECT ID>/gemma_2B
+gcloud storage cp -r LOCAL_DIRECTORY gs://<YOUR_BUCKET_NAME>/gemma_2B
 ```
 
 That command will do parallel composite uploads to speed up the uploading of the largest files in
@@ -48,7 +48,7 @@ that's not available in your preferred region, try with other machine types that
 in Cloud Build:
 * https://cloud.google.com/build/docs/api/reference/rest/v1/projects.builds#machinetype
 
-Moreover, the file `scripts/00_set_environment.sh` specifies a machine type for the Datalow workers.
+Moreover, the generated file `scripts/00_set_variables.sh` specifies a machine type for the Dataflow workers.
 The selected machine type, `g2-standard-4`, is the recommended one for inference with GPU. If that
 type is not available in your region, you can check what machines are available to use with the
 following command:
@@ -65,23 +65,16 @@ See more info about selecting the right type of machine in the following link:
 All the scripts are located in the `scripts` directory and prepared to be launched from the top 
 sources directory.
 
-In the script `scripts/00_set_environment.sh`, define the value of the project id and the region variable:
+The Terraform deployment automatically creates the environment script `scripts/00_set_variables.sh` with all the required resource names and configuration settings.
 
-```
-export PROJECT=<YOUR PROJECT ID>
-export REGION=<YOUR CLOUD REGION>
-```
-
-Leave the rest of variables untouched, although you can override them if you prefer.
-
-After you edit the script, load those variables into the environment
+Load those variables into the environment:
 
 ```sh
-source scripts/00_set_environment.sh
+source scripts/00_set_variables.sh
 ```
 
 And then run the script that builds and publishes the custom Dataflow container. This container will
-contain the Gemma model, and all the required dependencies.
+contain the Gemma model, and all the required dependencies:
 
 ```sh
 ./scripts/01_build_and_push_container.sh

--- a/pipelines/ml_ai_python/scripts/01_build_and_push_container.sh
+++ b/pipelines/ml_ai_python/scripts/01_build_and_push_container.sh
@@ -13,6 +13,7 @@
 #  limitations under the License.
 
 gcloud builds submit \
+  --project=$PROJECT \
   --region=$REGION \
   --default-buckets-behavior=regional-user-owned-bucket \
   --substitutions _TAG=$CONTAINER_URI,_GCS_GEMMA_PATH=$GCS_GEMMA_PATH \

--- a/pipelines/ml_ai_python/scripts/02_run_dataflow.sh
+++ b/pipelines/ml_ai_python/scripts/02_run_dataflow.sh
@@ -19,6 +19,9 @@ elif [ -n "$NETWORK" ]; then
   SUBNET_OPT="--subnetwork=$NETWORK"
 fi
 
+MACHINE_TYPE="n1-highmem-8"
+ACCELERATOR_OPT="worker_accelerator=type:nvidia-tesla-t4;count:1;install-nvidia-driver:5xx"
+
 python main.py \
   --runner=DataflowRunner \
   --project=$PROJECT \
@@ -29,11 +32,12 @@ python main.py \
   --num_workers=1 \
   --disk_size_gb=$DISK_SIZE_GB \
   --max_num_workers=$MAX_DATAFLOW_WORKERS \
-  --no_use_public_ip \
+  --number_of_worker_harness_threads=1 \
+  --no_use_public_ips \
   --service_account_email=$SERVICE_ACCOUNT \
   $SUBNET_OPT \
   --sdk_container_image=$CONTAINER_URI \
-  --dataflow_service_options="worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" \
+  --dataflow_service_options="$ACCELERATOR_OPT" \
   --messages_subscription=projects/$PROJECT/subscriptions/messages-sub \
   --responses_topic=projects/$PROJECT/topics/predictions \
   --model_path="gemma_2B"

--- a/pipelines/ml_ai_python/scripts/02_run_dataflow.sh
+++ b/pipelines/ml_ai_python/scripts/02_run_dataflow.sh
@@ -12,10 +12,17 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
+SUBNET_OPT=""
+if [ -n "$SUBNETWORK" ]; then
+  SUBNET_OPT="--subnetwork=$SUBNETWORK"
+elif [ -n "$NETWORK" ]; then
+  SUBNET_OPT="--subnetwork=$NETWORK"
+fi
+
 python main.py \
   --runner=DataflowRunner \
   --project=$PROJECT \
-  --temp_location=gs://$PROJECT/tmp \
+  --temp_location=$TEMP_LOCATION \
   --region=$REGION \
   --save_main_session \
   --machine_type=$MACHINE_TYPE \
@@ -24,7 +31,7 @@ python main.py \
   --max_num_workers=$MAX_DATAFLOW_WORKERS \
   --no_use_public_ip \
   --service_account_email=$SERVICE_ACCOUNT \
-  --subnetwork=$SUBNETWORK \
+  $SUBNET_OPT \
   --sdk_container_image=$CONTAINER_URI \
   --dataflow_service_options="worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" \
   --messages_subscription=projects/$PROJECT/subscriptions/messages-sub \

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -8,7 +8,7 @@ This directory contains Terraform infrastructure definitions for each solution g
 
 | Directory | Core Infrastructure Resources | Target Pipeline |
 | :--- | :--- | :--- |
-| `ml_ai/` | VPC, Subnet, NAT, GCS Bucket, Pub/Sub Topics (`messages`, `predictions`), Service Account | `pipelines/ml_ai_python/` |
+| `ml_ai/` | Pub/Sub Topics (`messages`, `predictions`), Artifact Registry (`dataflow-containers`), GCS Bucket, Service Account | `pipelines/ml_ai_python/` |
 | `etl_integration/` | Cloud Spanner (taxis DB + Change Stream), BigQuery Dataset, Service Account | `pipelines/etl_integration_java/` |
 | `cdp/` | Pub/Sub Topics (`transactions`, `coupon-redemption`), BigQuery Dataset, VPC, Subnet | `pipelines/cdp/` |
 | `anomaly_detection/` | Pub/Sub, BigQuery, Vertex AI Endpoint, VPC, Subnet | `pipelines/anomaly_detection/` |

--- a/terraform/TERRAFORM_REVAMP_GUIDE.md
+++ b/terraform/TERRAFORM_REVAMP_GUIDE.md
@@ -301,7 +301,7 @@ pylint --rcfile ../pylintrc .
 | 4 | **`anomaly_detection/`** | Pub/Sub Topic, BigQuery Dataset, Vertex AI Endpoint | `anomaly-detection-sa` | `pipelines/anomaly_detection/` |
 | 5 | **`marketing_intelligence/`** | Pub/Sub Topic, BigQuery Dataset, Vertex AI Model/Endpoint | `marketing-intel-sa` | `pipelines/marketing_intelligence/` |
 | 6 | **`iot_analytics/`** | Cloud Bigtable, Pub/Sub Topics, GCS Bucket | `iot-analytics-sa` | `pipelines/iot_analytics/` |
-| 7 | **`ml_ai/`** | Pub/Sub Topics (`messages`, `predictions`), GCS Bucket, GPU Quotas | `ml-ai-dataflow-sa` | `pipelines/ml_ai_python/` |
+| 7 | **`ml_ai/`** *(Done)* | Pub/Sub Topics (`messages`, `predictions`), Artifact Registry, GCS Bucket | `ml-ai-dataflow-sa` | `pipelines/ml_ai_python/` |
 | 8 | **`log_replication_splunk/`** | Pub/Sub Topic, Secret Manager (Splunk HEC token) | `splunk-replication-sa` | `pipelines/log_replication_splunk/` |
 
 ---

--- a/terraform/ml_ai/README.md
+++ b/terraform/ml_ai/README.md
@@ -1,29 +1,24 @@
-# GenAI & ML inference project deployment
+# GenAI & ML Inference
 
-This directory contains the Terraform code to spawn a Google Cloud project
-with all the necessary infrastructure and configuration required for running
-the GenAI & ML inference solution guide.
+This directory contains the Terraform code to deploy the minimum necessary Google Cloud
+infrastructure and permissions required for running the GenAI & ML inference solution guide.
 
 These deployment scripts are part of the
 [Dataflow Gen AI & ML solution guide](../../use_cases/GenAI_ML.md).
 
 ## Bill of resources created by this script
 
-The scripts will create the following resources
+The scripts will create the following resources:
 
-| Resource             |         Name          | Description                                                                                                                                                                                                                                                                                      |
-|:---------------------|:---------------------:|:-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| Project              |      Set by user      | Optional, you may reuse an existing project. If the project is created by Terraform, it will enable the APIs for Cloud Build, Dataflow,  Monitoring, Pub/Sub, Dataflow Autoscaling, and Artifact Registry                                                                                        |
+| Resource             |         Name          | Description                                                                                                                                                                                                                                                          |
+|:---------------------|:---------------------:|:---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
 | Docker registry      | `dataflow-containers` | An Artifact Registry Docker repo for the custom Dataflow container used in the pipeline. The Cloud Build service agent is granted admin role in this repository. The Dataflow service account is granted reader role. By default, only the 3 latest versions of each image are kept in the repo. |
-| Bucket               |  Same as project id   | Using the standard storage class, this is a regional bucket in the region specified by the user.                                                                                                                                                                                                 |
-| Pub/Sub topic        |      `messages`       | The input Pub/Sub topic for the sample pipeline.                                                                                                                                                                                                                                                 |
-| Pub/Sub topic        |     `predictions`     | The output Pub/Sub topic for the sample pipeline.                                                                                                                                                                                                                                                |
-| Pub/Sub subscription |    `messages-sub`     | The subscription to the `messages` topic that is actually used by the Dataflow pipeline.                                                                                                                                                                                                         |
-| Pub/Sub subscription |   `predictions-sub`   | The subscription to the `predictions` topic, useful to visualize the messages produced by the pipeline.                                                                                                                                                                                          |
-| Service account      |   `my-dataflow-sa`    | Dataflow worker servive account. It has storage admin, Dataflow worker, metrics writer and Pub/Sub editor roles assigned at project level.                                                                                                                                                       |
-| VPC network          |    `dataflow-net`     | If the project is created from scratch, the default network is removed and this network is re-created with a single regional sub-network.                                                                                                                                                        |
-| Cloud NAT            |    `dataflow-nat`     | Cloud NAT in the region specified by the user, in case the Dataflow workers need to reach the Internet. This is not necessary for the sample pipeline provided.                                                                                                                                  |
-| Firewall rules       |     Several rules     | Ingress and egress rules to remove unnecessary traffic, and to ensure the traffice required by Dataflow. If you want to access a VM using SSH, apply the network tag `ssh` to that instance. Same for `http-server` and for `https-server`                                                       |
+| Pub/Sub topic        |      `messages`       | The input Pub/Sub topic for the sample pipeline.                                                                                                                                                                                                                     |
+| Pub/Sub topic        |     `predictions`     | The output Pub/Sub topic for the sample pipeline.                                                                                                                                                                                                                    |
+| Pub/Sub subscription |    `messages-sub`     | The subscription to the `messages` topic that is used by the Dataflow pipeline.                                                                                                                                                                                      |
+| Pub/Sub subscription |   `predictions-sub`   | The subscription to the `predictions` topic, useful to inspect and visualize the predictions produced by the pipeline.                                                                                                                                              |
+| Service account      |  `ml-ai-dataflow-sa`  | Dedicated Dataflow worker service account. It has Dataflow worker, Storage object admin, metrics writer, Pub/Sub editor, and Artifact Registry reader roles assigned.                                                                                                |
+| GCS Bucket           |   Set by user (opt)   | Optional. A regional bucket for Dataflow temp and staging files, and for storing the Gemma model weights (created only if `create_bucket = true`).                                                                                                                  |
 
 ## Configuration variables
 
@@ -31,30 +26,25 @@ This deployment accepts the following configuration variables:
 
 | Variable                |   Type    | Description                                                                                                                                                                                                           |
 |:------------------------|:---------:|:----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-| `billing_account`       | `string`  | Optional. Billing account to be used if the project is created from scratch.                                                                                                                                          |
-| `organization`          | `string`  | Optional. Organization (or folder) number, <br/><br/><br/>where the project will be created. Only required if you are creating the project from scratch. Use the format `organizations/XXXXXXX` or `folder/XXXXXXXX`. |
-| `project_create`        | `boolean` | Set to false to reuse an existing project. Or to true to create a new project from scratch.                                                                                                                           | 
-| `project_id`            | `string`  | Project Id.                                                                                                                                                                                                           | 
-| `region`                | `string`  | Region to be used for all the resources. The VPC will contain only a single sub-network in this region.                                                                                                               |
-| `destroy_all_resources` |  `bool`   | Optional. Default true. Destroy buckets and the Spanner instance with `tf destroy `.                                                                                                                                  |
-| `network-prefix`        | `string`  | Optional. Default "dataflow". Add a prefix to the network net, subnet, NAT                                                                                                                                            |
-
-The default values of all the optional configuration variables are set for development projects.
-**For a production project, you should change `destroy_all_resources` to false.**
+| `project_id`            | `string`  | Required. Existing Google Cloud project ID where resources and IAM roles will be provisioned.                                                                                                                        |
+| `region`                | `string`  | Required. Region to be used for application resources, Artifact Registry, and Dataflow workers (e.g. `us-central1`).                                                                                                   |
+| `subnetwork`            | `string`  | Optional. Subnetwork URL or path for Dataflow workers (e.g., `regions/us-central1/subnetworks/dev-default` or full URI). If omitted, the default network is used.                                                      |
+| `service_account_name`  | `string`  | Optional. Name of the Dataflow worker service account to create. Defaults to `ml-ai-dataflow-sa`.                                                                                                                      |
+| `bucket_name`           | `string`  | Optional. Existing GCS bucket name for Dataflow temp/staging files and Gemma model weights. Defaults to `project_id` if omitted.                                                                                     |
+| `create_bucket`         |  `bool`   | Optional. Default `false`. Set to `true` if you want Terraform to create a new GCS bucket named `bucket_name` (or `project_id`).                                                                                      |
+| `destroy_all_resources` |  `bool`   | Optional. Default `true`. Set to `true` for test/demo environments to destroy all managed resources with `terraform destroy`. For production, set to `false`.                                                       |
 
 ## How to deploy
 
 1. **Set the configuration variables:**
-    - Create a file named `terraform.tfvars` in the current directory.
-    - Add the following configuration variables to the file, replacing the values with your own:
+    - Create a file named `terraform.tfvars` in this directory:
+      ```hcl
+      project_id            = "YOUR_PROJECT_ID"
+      region                = "us-central1"
+      subnetwork            = "regions/us-central1/subnetworks/YOUR_SUBNET" # Optional
+      bucket_name           = "YOUR_BUCKET_NAME"                           # Optional
+      destroy_all_resources = true
       ```
-      billing_account = "YOUR_BILLING_ACCOUNT"
-      organization = "YOUR_ORGANIZATION_ID"
-      project_create = true/false
-      project_id = "YOUR_PROJECT_ID"
-      region = "YOUR_REGION"
-      ```
-    - If this is a production deployment, make sure you change also the optional variables.
 2. **Initialize Terraform:**
     - Run the following command to initialize Terraform:
       ```bash
@@ -67,17 +57,27 @@ The default values of all the optional configuration variables are set for devel
       ```
 4. **Wait for the deployment to complete:**
     - Terraform will output the status of the deployment. Wait for it to complete successfully.
-5. **Access the deployed resources:** You are now ready to launch the sample pipeline in this
-   solution guide.
+
+## Scripts generation
+
+The Terraform code will generate a script with variable values, to be used
+with [the accompanying pipeline in this solution guide](../../pipelines/ml_ai_python/README.md).
+
+The script is written in the location `../../pipelines/ml_ai_python/scripts/00_set_variables.sh`, and should be sourced as follows:
+
+```bash
+source ./scripts/00_set_variables.sh
+```
 
 ## How to remove
 
 The setup will be continuously consuming as this is a streaming architecture, running without stop.
 
-**BEWARE: THE COMMAND BELOW WILL DESTROY AND REMOVE ALL THE RESOURCES**.
+**BEWARE: THE COMMAND BELOW WILL DESTROY AND REMOVE ALL THE MANAGED RESOURCES**.
 
 To destroy and stop all the resources, run:
 
 ```bash
 terraform destroy
 ```
+

--- a/terraform/ml_ai/main.tf
+++ b/terraform/ml_ai/main.tf
@@ -33,7 +33,8 @@ module "registry_docker" {
   format     = { docker = { standard = {} } }
   iam = {
     "roles/artifactregistry.admin" = [
-      "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
+      "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com",
+      "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
     ]
     "roles/artifactregistry.reader" = [
       module.dataflow_sa.iam_email

--- a/terraform/ml_ai/main.tf
+++ b/terraform/ml_ai/main.tf
@@ -13,40 +13,27 @@
 #  limitations under the License.
 
 locals {
-  dataflow_service_account = "my-dataflow-sa"
+  bucket_name              = var.bucket_name != null ? var.bucket_name : var.project_id
+  dataflow_service_account = var.service_account_name != null ? var.service_account_name : "ml-ai-dataflow-sa"
   max_dataflow_workers     = 1
   worker_disk_size_gb      = 200
   machine_type             = "g2-standard-4"
 }
 
-
-// Project
-module "google_cloud_project" {
-  source          = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/project?ref=v57.0.0"
-  billing_account = var.billing_account
-  project_reuse   = var.project_create ? null : {}
-  name            = var.project_id
-  parent          = var.organization
-  services = [
-    "serviceusage.googleapis.com",
-    "cloudbuild.googleapis.com",
-    "dataflow.googleapis.com",
-    "monitoring.googleapis.com",
-    "pubsub.googleapis.com",
-    "autoscaling.googleapis.com",
-    "artifactregistry.googleapis.com"
-  ]
+data "google_project" "project" {
+  project_id = var.project_id
 }
 
+// Artifact Registry repository for custom Dataflow GPU worker containers
 module "registry_docker" {
   source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/artifact-registry?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
+  project_id = var.project_id
   location   = var.region
   name       = "dataflow-containers"
   format     = { docker = { standard = {} } }
   iam = {
     "roles/artifactregistry.admin" = [
-      "serviceAccount:${module.google_cloud_project.number}@cloudbuild.gserviceaccount.com"
+      "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
     ]
     "roles/artifactregistry.reader" = [
       module.dataflow_sa.iam_email
@@ -63,19 +50,21 @@ module "registry_docker" {
   }
 }
 
-// Buckets for staging data, scripts, etc, in the two regions
+// Optional GCS Bucket for staging data and model weights
 module "buckets" {
+  count         = var.create_bucket ? 1 : 0
   source        = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/gcs?ref=v57.0.0"
-  project_id    = module.google_cloud_project.project_id
-  name          = module.google_cloud_project.project_id
+  project_id    = var.project_id
+  name          = local.bucket_name
   location      = var.region
   storage_class = "STANDARD"
   force_destroy = var.destroy_all_resources
 }
 
+// Pub/Sub Topics and Subscriptions
 module "input_topic" {
   source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
+  project_id = var.project_id
   name       = "messages"
   subscriptions = {
     messages-sub = {}
@@ -84,21 +73,21 @@ module "input_topic" {
 
 module "output_topic" {
   source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
+  project_id = var.project_id
   name       = "predictions"
   subscriptions = {
     predictions-sub = {}
   }
 }
 
-// Service account
+// Dedicated Dataflow Worker Service Account
 module "dataflow_sa" {
   source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/iam-service-account?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
+  project_id = var.project_id
   name       = local.dataflow_service_account
   iam_project_roles = {
-    (module.google_cloud_project.project_id) = [
-      "roles/storage.admin",
+    (var.project_id) = [
+      "roles/storage.objectAdmin",
       "roles/dataflow.worker",
       "roles/monitoring.metricWriter",
       "roles/pubsub.editor"
@@ -106,70 +95,18 @@ module "dataflow_sa" {
   }
 }
 
-// Network
-module "vpc_network" {
-  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/net-vpc?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
-  name       = "${var.network_prefix}-net"
-  subnets = [
-    {
-      ip_cidr_range         = "10.1.0.0/16"
-      name                  = "${var.network_prefix}-subnet"
-      region                = var.region
-      enable_private_access = true
-      secondary_ip_ranges = {
-        pods     = { ip_cidr_range = "10.16.0.0/14" }
-        services = { ip_cidr_range = "10.20.0.0/24" }
-      }
-    }
-  ]
-}
-
-module "firewall_rules" {
-  // Default rules for internal traffic + SSH access via IAP
-  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/net-vpc-firewall?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
-  network    = module.vpc_network.name
-  default_rules_config = {
-    admin_ranges = [
-      module.vpc_network.subnet_ips["${var.region}/${var.network_prefix}-subnet"],
-    ]
-  }
-  egress_rules = {
-    allow-egress-dataflow = {
-      deny        = false
-      description = "Dataflow firewall rule egress"
-      targets     = ["dataflow"]
-      rules       = [{ protocol = "tcp", ports = [12345, 12346] }]
-    }
-  }
-  ingress_rules = {
-    allow-ingress-dataflow = {
-      description = "Dataflow firewall rule ingress"
-      targets     = ["dataflow"]
-      rules       = [{ protocol = "tcp", ports = [12345, 12346] }]
-    }
-  }
-}
-module "regional_nat" {
-  // So we can get to Internet if necessary (from the Dataflow region)
-  source         = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/net-cloudnat?ref=v57.0.0"
-  project_id     = module.google_cloud_project.project_id
-  region         = var.region
-  name           = "${var.network_prefix}-nat"
-  router_network = module.vpc_network.self_link
-}
-
+// Script with variables to launch the Dataflow jobs
 resource "local_file" "variables_script" {
   filename        = "${path.module}/../../pipelines/ml_ai_python/scripts/00_set_variables.sh"
   file_permission = "0644"
   content         = <<FILE
 # This file is generated by the Terraform code of this Solution Guide.
 # We recommend that you modify this file only through the Terraform deployment.
-export PROJECT=${module.google_cloud_project.project_id}
+export PROJECT=${var.project_id}
 export REGION=${var.region}
-export SUBNETWORK=regions/${var.region}/subnetworks/${var.network_prefix}-subnet
-export TEMP_LOCATION=gs://$PROJECT/tmp
+export SUBNETWORK=${var.subnetwork != null ? var.subnetwork : ""}
+export NETWORK=$${SUBNETWORK}
+export TEMP_LOCATION=gs://${local.bucket_name}/tmp
 export SERVICE_ACCOUNT=${module.dataflow_sa.email}
 
 export DOCKER_REPOSITORY=${module.registry_docker.name}
@@ -177,7 +114,7 @@ export IMAGE_NAME=dataflow-solutions-ml-ai
 export DOCKER_TAG=0.1
 export DOCKER_IMAGE=$REGION-docker.pkg.dev/$PROJECT/$DOCKER_REPOSITORY/$IMAGE_NAME
 
-export GCS_GEMMA_PATH=gs://$PROJECT/gemma_2B
+export GCS_GEMMA_PATH=gs://${local.bucket_name}/gemma_2B
 export CONTAINER_URI=$DOCKER_IMAGE:$DOCKER_TAG
 
 export MAX_DATAFLOW_WORKERS=${local.max_dataflow_workers}

--- a/terraform/ml_ai/variables.tf
+++ b/terraform/ml_ai/variables.tf
@@ -12,42 +12,43 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-variable "billing_account" {
-  description = "Billing account for the projects/resources"
-  type        = string
-  default     = null
-}
-
-variable "destroy_all_resources" {
-  description = "Destroy all resources when calling tf destroy. Use false for production deployments. For test environments, set to true to remove all buckets and Spanner instances."
-  type        = bool
-  default     = true
-}
-
-variable "network_prefix" {
-  description = "Prefix to be used for networks and subnetworks"
-  type        = string
-  default     = "dataflow"
-}
-
-variable "organization" {
-  description = "Organization for the project/resources"
-  type        = string
-  default     = null
-}
-
-variable "project_create" {
-  description = "True if you want to create a new project. False to reuse an existing project."
-  type        = bool
-}
-
 variable "project_id" {
-  description = "Project ID for the project/resources"
+  description = "Project ID of the existing GCP project where resources will be provisioned."
   type        = string
 }
 
 variable "region" {
-  description = "The region for resources and networking"
+  description = "The GCP region for application resources and Dataflow jobs."
   type        = string
+}
+
+variable "subnetwork" {
+  description = "Optional subnetwork URL or path for Dataflow workers (e.g. regions/europe-southwest1/subnetworks/dev-default or full URI). If omitted, the default network is used."
+  type        = string
+  default     = null
+}
+
+variable "bucket_name" {
+  description = "Optional GCS bucket name for Dataflow temp/staging files. Defaults to project_id if not specified."
+  type        = string
+  default     = null
+}
+
+variable "service_account_name" {
+  description = "Name of the dedicated Dataflow worker service account to create."
+  type        = string
+  default     = "ml-ai-dataflow-sa"
+}
+
+variable "create_bucket" {
+  description = "Whether to create a new GCS bucket for temp/staging files. Set to false if using an existing bucket."
+  type        = bool
+  default     = false
+}
+
+variable "destroy_all_resources" {
+  description = "Destroy all resources when calling tf destroy. Use false for production deployments. For test environments, set to true to remove all resources."
+  type        = bool
+  default     = true
 }
 

--- a/use_cases/GenAI_ML.md
+++ b/use_cases/GenAI_ML.md
@@ -19,7 +19,7 @@ For the full documentation of this solution guide, please refer to:
 
 ## Assets included in this repository
 
-- [Terraform code to deploy a project for GenAI & ML inference](../terraform/ml_ai/)
+- [Terraform code to deploy infrastructure for GenAI & ML inference](../terraform/ml_ai/)
 - [Sample pipeline in Python for leveraging the Gemma open LLM with Dataflow](../pipelines/ml_ai_python/)
 
 ## Technical benefits


### PR DESCRIPTION
## Description
This PR refactors and modernizes the Terraform infrastructure and pipeline scripts for the **GenAI & Machine Learning inference** solution guide (`terraform/ml_ai` and `pipelines/ml_ai_python`), following the pattern established for the ETL/Integration use case in #221.

### Key Changes
- **Lightweight Application Infrastructure (`terraform/ml_ai`)**:
  - Removed foundation-level resource creation (`google_cloud_project`, `vpc_network`, `firewall_rules`, `regional_nat`).
  - Simplified inputs to application variables: `project_id`, `region`, `subnetwork`, `bucket_name`, `service_account_name`, `create_bucket`, `destroy_all_resources`.
  - Upgraded Google Cloud Foundation Fabric module sources to `v57.0.0`.
  - Added modern Cloud Build service account (`[PROJECT_NUMBER]-compute@developer.gserviceaccount.com`) to Artifact Registry admin permissions.
- **Pipeline Scripts & Runtime Compatibility (`pipelines/ml_ai_python`)**:
  - Generated dynamic `00_set_variables.sh` environment configuration.
  - Aligned Beam SDK version in `Dockerfile` (`apache/beam_python3.11_sdk:2.75.0`) to match `requirements.txt`.
  - Added `--no_use_public_ips`, `--number_of_worker_harness_threads=1`, and flexible GPU accelerator configuration to `02_run_dataflow.sh`.
  - Added Python 3.11 version matching documentation to `pipelines/ml_ai_python/README.md`.
- **Documentation**:
  - Updated `terraform/ml_ai/README.md`, `pipelines/ml_ai_python/README.md`, `use_cases/GenAI_ML.md`, and `terraform/TERRAFORM_REVAMP_GUIDE.md`.

### Verification
- Deployed infrastructure, built container image with Gemma 2B model weights, and launched streaming Dataflow GPU job on Google Cloud.
- Verified prompt submission to Pub/Sub topic `messages` and received valid inference output from `predictions-sub`.
- Clean teardown executed via `terraform destroy`.