### PR TITLE
fix(pipelines): standardize Beam SDK 2.75.0 version parity and update agent skills

### DIFF
--- a/.agents/skills/dataflow-pipeline-dev/SKILL.md
+++ b/.agents/skills/dataflow-pipeline-dev/SKILL.md
@@ -59,7 +59,8 @@ python main.py \
 ```
 
 ### Step 6: Custom SDK Container Build (if required)
-For pipelines using GPU acceleration or custom C/Python libraries (e.g. `ml_ai_python`):
+For pipelines using GPU acceleration, custom C/Python libraries, or specialized base images (e.g. `ml_ai_python`, `anomaly_detection`, `cdp`, `iot_analytics`, `marketing_intelligence`):
+- **SDK Version Parity**: Verify that the `apache/beam_python3.11_sdk:<version>` tag in `Dockerfile` matches `requirements.txt` (`apache-beam[gcp]==<version>`).
 ```bash
 # Set required image tag
 export CONTAINER_URI="gcr.io/$PROJECT/dataflow-ml-custom:latest"
@@ -100,13 +101,15 @@ Run the pipeline locally:
 
 ## 3. Apache Beam Best Practices in this Repo
 
-1. **Option Classes**:
+1. **SDK & Custom Container Parity**:
+   The Apache Beam SDK version in the pipeline code (`requirements.txt`) and worker container (`Dockerfile`) must be identical. Version divergence leads to serialization failures, container harness mismatch, and worker initialization crashes on Dataflow.
+2. **Option Classes**:
    Define pipeline arguments by subclassing `PipelineOptions` (Python) or `PipelineOptions` interface (Java) in `options.py` / `options/`.
-2. **Worker Isolation**:
+3. **Worker Isolation**:
    Always enforce private IP communication:
    - Python: `--no_use_public_ip`
    - Java: `--usePublicIps=false`
-3. **Dead-Letter Queues (Side Outputs)**:
+4. **Dead-Letter Queues (Side Outputs)**:
    For unparseable or error records, route failed elements to a dead-letter output or BigQuery error table rather than crashing worker threads:
    ```python
    # Python side-output pattern
@@ -115,7 +118,7 @@ Run the pipeline locally:
        | 'ParseRecords' >> beam.ParDo(ParseDoFn()).with_outputs('errors', main='valid')
    )
    ```
-4. **Metrics Instrumentation**:
+5. **Metrics Instrumentation**:
    Use Beam metrics to track throughput and error counts:
    ```python
    self.processed_counter = Metrics.counter(self.__class__, 'processed_elements')

--- a/.agents/skills/dataflow-troubleshooting/SKILL.md
+++ b/.agents/skills/dataflow-troubleshooting/SKILL.md
@@ -92,3 +92,16 @@ This skill provides diagnostic workflows and solutions for common failures encou
       --substitutions _TAG=$CONTAINER_URI \
       .
     ```
+
+---
+
+## 6. Custom Container & Beam SDK Version Mismatches
+
+### Symptom: Worker crashes on startup with `SDK harness failed to connect`, `Incompatible SDK version`, or serialization / unpickling errors
+* **Root Cause: Mismatch between pipeline submission environment and worker image**
+  * The pipeline graph was generated using an `apache-beam` version in the launching environment (e.g. `requirements.txt` = `2.75.0`), but the worker custom container used a different version in `Dockerfile` (e.g. `COPY --from=apache/beam_python3.11_sdk:2.76.0 /opt/apache/beam /opt/apache/beam`).
+  * **Fix**:
+    1. Check the Beam version in `requirements.txt` (`grep apache-beam requirements.txt`).
+    2. Check the container base and boot image tag in `Dockerfile` (`grep apache/beam Dockerfile`).
+    3. Ensure both specify the exact same version (e.g., both `2.75.0`).
+    4. Rebuild the custom container via Cloud Build and resubmit the Dataflow job.

--- a/.agents/skills/pr-review/SKILL.md
+++ b/.agents/skills/pr-review/SKILL.md
@@ -44,6 +44,10 @@ Before approving or merging, identify the PR type and apply the corresponding ch
 ### A. Dependency Updates (Renovate / Dependabot)
 * [ ] **Builds Pass**: Confirm `Build and validation` workflow passes all jobs (Java, Python, Terraform, Docker).
 * [ ] **Compatibility**: Ensure upgraded versions (e.g. Gradle plugins, Python libraries, Cloud Foundation Fabric modules) maintain backward compatibility.
+* [ ] **Beam SDK & Container Parity**:
+  - If `apache/beam_python3.11_sdk` Docker tag is updated, verify `requirements.txt` (`apache-beam[gcp]==<version>`) is updated concurrently.
+  - Verify that the target `apache-beam` release is published and generally available on PyPI (not just release candidates).
+  - Do NOT merge isolated Dockerfile upgrades if the corresponding PyPI package is missing or `requirements.txt` is not kept in sync.
 * [ ] **Sync Across Pipelines**: If a shared plugin/dependency is updated, check if other pipelines should also be kept in sync.
 * [ ] **Rebase State**: If the PR was created by a bot and has conflicts, ensure it is cleanly rebased on the latest `main`.
 
@@ -58,6 +62,7 @@ Before approving or merging, identify the PR type and apply the corresponding ch
 * [ ] **Formatting**: Formatted with `yapf -i -r --style yapf .`.
 * [ ] **Linting**: 0 errors from `pylint --rcfile ../pylintrc .`.
 * [ ] **Package Build**: `python setup.py sdist` builds source distribution without missing files.
+* [ ] **SDK & Container Parity**: `Dockerfile` (`apache/beam_python3.11_sdk:<version>`) and `requirements.txt` (`apache-beam[gcp]==<version>`) use the exact same version.
 * [ ] **Pipeline Options**: Private IPs enforced (`--no_use_public_ip`), dedicated service account specified.
 * [ ] **DoFn Serialization**: Heavy/network objects initialized in `setup()`, not `__init__()`.
 * [ ] **Custom Container / Cloud Build**: If custom SDK container is used, `Dockerfile` and `cloudbuild.yaml` follow repo standards.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -143,6 +143,9 @@ When authoring or modifying code in this repository, strictly adhere to the foll
    - Always run Dataflow jobs with a dedicated custom service account (`--service_account_email` / `--serviceAccount`).
    - Grant least-privilege roles (e.g., `roles/dataflow.worker`, `roles/storage.objectAdmin`, `roles/pubsub.editor`, `roles/bigquery.dataEditor`, `roles/spanner.databaseUser`).
    - Never use the default Compute Engine service account.
+5. **Beam SDK & Custom Container Version Parity**:
+   - The Apache Beam SDK version pinned in `requirements.txt` (`apache-beam[gcp]==<version>`) and the base/boot image tag in `Dockerfile` (`apache/beam_python3.11_sdk:<version>`) **must strictly match**.
+   - Do not upgrade container tags unless the matching stable SDK package is published to PyPI and `requirements.txt` is updated in the same change.
 
 ---
 

--- a/pipelines/AGENTS.md
+++ b/pipelines/AGENTS.md
@@ -87,8 +87,12 @@ Java pipelines use Gradle with standard Google Cloud Dataflow plugins and spotle
 ## 4. Custom Containers & Cloud Build
 
 For pipelines leveraging custom dependencies or machine learning models on GPU workers (e.g. `ml_ai_python`):
-1. The `Dockerfile` builds on top of `apache/beam_python3.11_sdk`.
-2. Cloud Build builds and registers the container image in Google Artifact Registry / Google Container Registry:
+1. **SDK and Container Version Parity (Mandatory)**:
+   The `apache/beam_python3.11_sdk:<version>` tag in `Dockerfile` (both `FROM` and `COPY --from=...`) **must strictly match** the `apache-beam[gcp]==<version>` dependency pinned in `requirements.txt`.
+   - Never upgrade container image tags without verifying that the matching stable `apache-beam` release is available on PyPI and updating `requirements.txt` in tandem.
+   - A version mismatch between the pipeline submission environment and the worker container harness will cause serialization errors or worker startup failures.
+2. The `Dockerfile` builds on top of `apache/beam_python3.11_sdk`.
+3. Cloud Build builds and registers the container image in Google Artifact Registry / Google Container Registry:
    ```bash
    gcloud builds submit \
      --region=$REGION \
@@ -96,7 +100,7 @@ For pipelines leveraging custom dependencies or machine learning models on GPU w
      --substitutions _TAG=$CONTAINER_URI \
      .
    ```
-3. When submitting the pipeline to Dataflow, specify:
+4. When submitting the pipeline to Dataflow, specify:
    ```bash
    --sdk_container_image=$CONTAINER_URI
    ```

--- a/pipelines/anomaly_detection/Dockerfile
+++ b/pipelines/anomaly_detection/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --upgrade --no-cache-dir pip \
   && pip install --no-cache-dir -e .
 
 # Copy files from official SDK image, including script/dependencies.
-COPY --from=apache/beam_python3.11_sdk:2.76.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.11_sdk:2.75.0 /opt/apache/beam /opt/apache/beam
 
 
 ENV KERAS_BACKEND="tensorflow"

--- a/pipelines/cdp/Dockerfile
+++ b/pipelines/cdp/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM apache/beam_python3.11_sdk:2.76.0
+FROM apache/beam_python3.11_sdk:2.75.0
 WORKDIR /workspace
 
 RUN apt-get update -y && apt-get install -y \
@@ -30,7 +30,7 @@ RUN pip install --upgrade --no-cache-dir pip \
   && pip install --no-cache-dir -e .
 
 # Copy files from official SDK image, including script/dependencies.
-COPY --from=apache/beam_python3.11_sdk:2.76.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.11_sdk:2.75.0 /opt/apache/beam /opt/apache/beam
 
 # Set the entrypoint to Apache Beam SDK launcher.
 ENTRYPOINT ["/opt/apache/beam/boot"]

--- a/pipelines/iot_analytics/Dockerfile
+++ b/pipelines/iot_analytics/Dockerfile
@@ -12,7 +12,7 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-FROM apache/beam_python3.11_sdk:2.76.0
+FROM apache/beam_python3.11_sdk:2.75.0
 WORKDIR /workspace
 
 RUN apt-get update -y && apt-get install -y \
@@ -30,7 +30,7 @@ RUN pip install --upgrade --no-cache-dir pip \
   && pip install --no-cache-dir -e .
 
 # Copy files from official SDK image, including script/dependencies.
-COPY --from=apache/beam_python3.11_sdk:2.76.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.11_sdk:2.75.0 /opt/apache/beam /opt/apache/beam
 
 # Set the entrypoint to Apache Beam SDK launcher.
 ENTRYPOINT ["/opt/apache/beam/boot"]

--- a/pipelines/marketing_intelligence/Dockerfile
+++ b/pipelines/marketing_intelligence/Dockerfile
@@ -30,7 +30,7 @@ RUN pip install --upgrade --no-cache-dir pip \
   && pip install --no-cache-dir -e .
 
 # Copy files from official SDK image, including script/dependencies.
-COPY --from=apache/beam_python3.11_sdk:2.76.0 /opt/apache/beam /opt/apache/beam
+COPY --from=apache/beam_python3.11_sdk:2.75.0 /opt/apache/beam /opt/apache/beam
 
 
 ENV KERAS_BACKEND="tensorflow"


### PR DESCRIPTION
## Description
This PR standardizes Apache Beam SDK version parity across all pipeline custom containers, requirements files, and agent skills:

1. **Revert Dockerfiles to 2.75.0**:
   - Reverts `pipelines/anomaly_detection/Dockerfile`, `pipelines/cdp/Dockerfile`, `pipelines/iot_analytics/Dockerfile`, and `pipelines/marketing_intelligence/Dockerfile` to `apache/beam_python3.11_sdk:2.75.0`.
   - Establishes 100% parity across all 5 Python pipelines (`requirements.txt` <-> `Dockerfile`), Java pipelines (`beamVersion = "2.75.0"`), and the latest stable PyPI release (`apache-beam==2.75.0`).

2. **Hardened Guidelines & Custom Skills**:
   - Updated `AGENTS.md` and `pipelines/AGENTS.md` with mandatory SDK & worker container version parity requirements.
   - Updated `.agents/skills/dataflow-pipeline-dev` with SDK version parity checks in custom container build instructions.
   - Updated `.agents/skills/pr-review` with checklist items ensuring automated dependency PRs (like Renovate) do not upgrade Docker images without corresponding stable PyPI packages and synchronized `requirements.txt` updates.
   - Updated `.agents/skills/dataflow-troubleshooting` with a diagnostic runbook for container/SDK version mismatch errors.
