### PR TITLE
ci: make CI builds selective and path-aware for pipelines and containers

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -52,11 +52,21 @@ jobs:
         if: steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true'
         id: targets
         working-directory: terraform
+        env:
+          IS_WORKFLOW: ${{ steps.filter.outputs.workflow }}
+          FILES_JSON: ${{ steps.filter.outputs.terraform_files }}
         run: |
-          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
-            DIRS=$(ls -d */ | sed 's#/##' | tr '\n' ' ')
+          if [ "$IS_WORKFLOW" = "true" ]; then
+            DIRS=""
+            for d in */; do
+              if [ -d "$d" ]; then
+                DIRS="$DIRS ${d%/}"
+              fi
+            done
+            DIRS="${DIRS# }"
           else
-            DIRS=$(echo '${{ steps.filter.outputs.terraform_files }}' | jq -r '.[] | select(startswith("terraform/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("terraform/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS="${DIRS% }"
           fi
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           echo "Target Terraform modules: $DIRS"
@@ -66,34 +76,40 @@ jobs:
       - name: Terraform Init
         if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: terraform
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
-          for d in ${{ steps.targets.outputs.dirs }}
+          for d in $TARGET_DIRS
           do
             if [ -d "$d" ]; then
               echo "Running tf init in directory: $d"
-              cd $d && terraform init && cd ..
+              cd "$d" && terraform init && cd ..
             fi
           done
       - name: Terraform Format
         if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: terraform
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
-          for d in ${{ steps.targets.outputs.dirs }}
+          for d in $TARGET_DIRS
           do
             if [ -d "$d" ]; then
               echo "Running tf format check in directory: $d"
-              cd $d && terraform fmt -check && cd ..
+              cd "$d" && terraform fmt -check && cd ..
             fi
           done
       - name: Terraform Validate
         if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: terraform
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
-          for d in ${{ steps.targets.outputs.dirs }}
+          for d in $TARGET_DIRS
           do
             if [ -d "$d" ]; then
               echo "Running tf validate in directory: $d"
-              cd $d && terraform validate && cd ..
+              cd "$d" && terraform validate && cd ..
             fi
           done
   java-build:
@@ -121,11 +137,21 @@ jobs:
         if: steps.filter.outputs.java == 'true' || steps.filter.outputs.workflow == 'true'
         id: targets
         working-directory: pipelines
+        env:
+          IS_WORKFLOW: ${{ steps.filter.outputs.workflow }}
+          FILES_JSON: ${{ steps.filter.outputs.java_files }}
         run: |
-          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
-            DIRS=$(for d in */; do [ -f "$d/gradlew" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          if [ "$IS_WORKFLOW" = "true" ]; then
+            DIRS=""
+            for d in */; do
+              if [ -f "$d/gradlew" ]; then
+                DIRS="$DIRS ${d%/}"
+              fi
+            done
+            DIRS="${DIRS# }"
           else
-            DIRS=$(echo '${{ steps.filter.outputs.java_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS="${DIRS% }"
           fi
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           echo "Target Java pipelines: $DIRS"
@@ -147,14 +173,16 @@ jobs:
       - name: Build with Gradle Wrapper
         if: (steps.filter.outputs.java == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
-          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
+          for pipeline_dir in $TARGET_DIRS
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/gradlew" ]
             then
               echo Gradle build found
-              cd $pipeline_dir
+              cd "$pipeline_dir"
               ./gradlew build
               cd ..
             else
@@ -185,11 +213,21 @@ jobs:
         if: steps.filter.outputs.pylint == 'true' || steps.filter.outputs.shared == 'true'
         id: targets
         working-directory: pipelines
+        env:
+          IS_SHARED: ${{ steps.filter.outputs.shared }}
+          FILES_JSON: ${{ steps.filter.outputs.pylint_files }}
         run: |
-          if [ "${{ steps.filter.outputs.shared }}" = "true" ]; then
-            DIRS=$(for d in */; do [ -f "$d/setup.py" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          if [ "$IS_SHARED" = "true" ]; then
+            DIRS=""
+            for d in */; do
+              if [ -f "$d/setup.py" ]; then
+                DIRS="$DIRS ${d%/}"
+              fi
+            done
+            DIRS="${DIRS# }"
           else
-            DIRS=$(echo '${{ steps.filter.outputs.pylint_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS="${DIRS% }"
           fi
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           echo "Target PyLint pipelines: $DIRS"
@@ -206,18 +244,20 @@ jobs:
       - name: Run pylint
         if: (steps.filter.outputs.pylint == 'true' || steps.filter.outputs.shared == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
-          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
+          for pipeline_dir in $TARGET_DIRS
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/setup.py" ]
             then
               echo
               echo -------------------------------------
-              echo Checking format $pipeline_dir
+              echo Checking format "$pipeline_dir"
               echo -------------------------------------
               echo
-              cd $pipeline_dir
+              cd "$pipeline_dir"
               pylint --rcfile ../pylintrc .
               cd ..
             else
@@ -248,11 +288,21 @@ jobs:
         if: steps.filter.outputs.python == 'true' || steps.filter.outputs.workflow == 'true'
         id: targets
         working-directory: pipelines
+        env:
+          IS_WORKFLOW: ${{ steps.filter.outputs.workflow }}
+          FILES_JSON: ${{ steps.filter.outputs.python_files }}
         run: |
-          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
-            DIRS=$(for d in */; do [ -f "$d/setup.py" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          if [ "$IS_WORKFLOW" = "true" ]; then
+            DIRS=""
+            for d in */; do
+              if [ -f "$d/setup.py" ]; then
+                DIRS="$DIRS ${d%/}"
+              fi
+            done
+            DIRS="${DIRS# }"
           else
-            DIRS=$(echo '${{ steps.filter.outputs.python_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS="${DIRS% }"
           fi
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           echo "Target Python pipelines: $DIRS"
@@ -267,24 +317,26 @@ jobs:
       - name: Python builds
         if: (steps.filter.outputs.python == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
           export PIPENV_VENV_IN_PROJECT=1
-          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
+          for pipeline_dir in $TARGET_DIRS
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/setup.py" ]
             then
               echo
               echo -------------------------------------
-              echo Building $pipeline_dir
+              echo Building "$pipeline_dir"
               echo -------------------------------------
               echo
-              cd $pipeline_dir
+              cd "$pipeline_dir"
               pipenv install
               for req_txt in requirements*.txt
               do
-                echo ----- Installing dependencies in $req_txt -----
-                pipenv install -r $req_txt
+                echo ----- Installing dependencies in "$req_txt" -----
+                pipenv install -r "$req_txt"
               done
               echo ----- Building package -----
               pipenv run python setup.py sdist
@@ -320,11 +372,21 @@ jobs:
         if: steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflow == 'true'
         id: targets
         working-directory: pipelines
+        env:
+          IS_WORKFLOW: ${{ steps.filter.outputs.workflow }}
+          FILES_JSON: ${{ steps.filter.outputs.docker_files }}
         run: |
-          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
-            DIRS=$(for d in */; do [ -f "$d/Dockerfile" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          if [ "$IS_WORKFLOW" = "true" ]; then
+            DIRS=""
+            for d in */; do
+              if [ -f "$d/Dockerfile" ]; then
+                DIRS="$DIRS ${d%/}"
+              fi
+            done
+            DIRS="${DIRS# }"
           else
-            DIRS=$(echo '${{ steps.filter.outputs.docker_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+            DIRS="${DIRS% }"
           fi
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           echo "Target Docker containers: $DIRS"
@@ -333,18 +395,20 @@ jobs:
       - name: Docker builds
         if: (steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
+        env:
+          TARGET_DIRS: ${{ steps.targets.outputs.dirs }}
         run: |
-          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
+          for pipeline_dir in $TARGET_DIRS
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/Dockerfile" ]
             then
               echo
               echo -------------------------------------
-              echo Building Docker $pipeline_dir
+              echo Building Docker "$pipeline_dir"
               echo -------------------------------------
               echo
-              cd $pipeline_dir
+              cd "$pipeline_dir"
               mkdir -p gemma_2B && touch gemma_2B/DUMMY
               docker build -t github-actions .
               cd ..

--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -42,39 +42,59 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          list-files: json
           filters: |
+            workflow:
+              - '.github/workflows/pull_request.yml'
             terraform:
               - 'terraform/**'
-              - '.github/workflows/pull_request.yml'
+      - name: Detect target Terraform modules
+        if: steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true'
+        id: targets
+        working-directory: terraform
+        run: |
+          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+            DIRS=$(ls -d */ | sed 's#/##' | tr '\n' ' ')
+          else
+            DIRS=$(echo '${{ steps.filter.outputs.terraform_files }}' | jq -r '.[] | select(startswith("terraform/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+          fi
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          echo "Target Terraform modules: $DIRS"
       - name: Setup Terraform
-        if: steps.filter.outputs.terraform == 'true'
+        if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         uses: hashicorp/setup-terraform@dfe3c3f87815947d99a8997f908cb6525fc44e9e # v4.0.1
       - name: Terraform Init
-        if: steps.filter.outputs.terraform == 'true'
+        if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: terraform
         run: |
-          ls -d */ | while read d
+          for d in ${{ steps.targets.outputs.dirs }}
           do
-          echo "Running tf init in directory: $d"
-          cd $d && terraform init && cd ..
+            if [ -d "$d" ]; then
+              echo "Running tf init in directory: $d"
+              cd $d && terraform init && cd ..
+            fi
           done
       - name: Terraform Format
-        if: steps.filter.outputs.terraform == 'true'
+        if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: terraform
         run: |
-          ls -d */ | while read d
+          for d in ${{ steps.targets.outputs.dirs }}
           do
-          echo "Running tf format check in directory: $d"
-          cd $d && terraform fmt -check && cd ..
+            if [ -d "$d" ]; then
+              echo "Running tf format check in directory: $d"
+              cd $d && terraform fmt -check && cd ..
+            fi
           done
       - name: Terraform Validate
-        if: steps.filter.outputs.terraform == 'true'
+        if: (steps.filter.outputs.terraform == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: terraform
         run: |
-          ls -d */ | while read d
+          for d in ${{ steps.targets.outputs.dirs }}
           do
-          echo "Running tf validate in directory: $d"
-          cd $d && terraform validate && cd ..
+            if [ -d "$d" ]; then
+              echo "Running tf validate in directory: $d"
+              cd $d && terraform validate && cd ..
+            fi
           done
   java-build:
     name: 'Java pipelines build'
@@ -87,16 +107,30 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          list-files: json
           filters: |
+            workflow:
+              - '.github/workflows/pull_request.yml'
             java:
               - 'pipelines/*_java/**'
               - 'pipelines/**/*.java'
               - 'pipelines/**/build.gradle'
               - 'pipelines/**/gradle/**'
               - 'pipelines/**/gradlew*'
-              - '.github/workflows/pull_request.yml'
+      - name: Detect target Java pipelines
+        if: steps.filter.outputs.java == 'true' || steps.filter.outputs.workflow == 'true'
+        id: targets
+        working-directory: pipelines
+        run: |
+          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+            DIRS=$(for d in */; do [ -f "$d/gradlew" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          else
+            DIRS=$(echo '${{ steps.filter.outputs.java_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+          fi
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          echo "Target Java pipelines: $DIRS"
       - name: Set up JDK 25
-        if: steps.filter.outputs.java == 'true'
+        if: (steps.filter.outputs.java == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         uses: actions/setup-java@dd06d9cba3e5552c54d9f8ea23572deb30010f7c # v6.0.0
         with:
           java-version: '25'
@@ -104,17 +138,17 @@ jobs:
       # Configure Gradle for optimal use in GitHub Actions, including caching of downloaded dependencies.
       # See: https://github.com/gradle/actions/blob/main/setup-gradle/README.md
       - name: Setup Gradle
-        if: steps.filter.outputs.java == 'true'
+        if: (steps.filter.outputs.java == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         uses: gradle/actions/setup-gradle@9c971963bec38e04b3d30dcc455b5382be2fdbfb # v6.3.0
         with:
           build-scan-publish: true
           build-scan-terms-of-use-url: "https://gradle.com/terms-of-service"
           build-scan-terms-of-use-agree: "yes"
       - name: Build with Gradle Wrapper
-        if: steps.filter.outputs.java == 'true'
+        if: (steps.filter.outputs.java == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
         run: |
-          for pipeline_dir in */
+          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/gradlew" ]
@@ -138,28 +172,42 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          list-files: json
           filters: |
+            shared:
+              - 'pipelines/pylintrc'
+              - '.github/workflows/pull_request.yml'
             pylint:
               - 'pipelines/**/*.py'
-              - 'pipelines/pylintrc'
               - 'pipelines/**/setup.py'
               - 'pipelines/**/requirements*.txt'
-              - '.github/workflows/pull_request.yml'
+      - name: Detect target Python pipelines for PyLint
+        if: steps.filter.outputs.pylint == 'true' || steps.filter.outputs.shared == 'true'
+        id: targets
+        working-directory: pipelines
+        run: |
+          if [ "${{ steps.filter.outputs.shared }}" = "true" ]; then
+            DIRS=$(for d in */; do [ -f "$d/setup.py" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          else
+            DIRS=$(echo '${{ steps.filter.outputs.pylint_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+          fi
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          echo "Target PyLint pipelines: $DIRS"
       - name: Setup Python
-        if: steps.filter.outputs.pylint == 'true'
+        if: (steps.filter.outputs.pylint == 'true' || steps.filter.outputs.shared == 'true') && steps.targets.outputs.dirs != ''
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       - name: Install pylint
-        if: steps.filter.outputs.pylint == 'true'
+        if: (steps.filter.outputs.pylint == 'true' || steps.filter.outputs.shared == 'true') && steps.targets.outputs.dirs != ''
         run: |
           python -m pip install --upgrade pip
           pip install pylint
       - name: Run pylint
-        if: steps.filter.outputs.pylint == 'true'
+        if: (steps.filter.outputs.pylint == 'true' || steps.filter.outputs.shared == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
         run: |
-          for pipeline_dir in */
+          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/setup.py" ]
@@ -187,27 +235,41 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          list-files: json
           filters: |
+            workflow:
+              - '.github/workflows/pull_request.yml'
             python:
               - 'pipelines/**/*.py'
               - 'pipelines/**/setup.py'
               - 'pipelines/**/requirements*.txt'
               - 'pipelines/**/Pipfile*'
-              - '.github/workflows/pull_request.yml'
+      - name: Detect target Python pipelines
+        if: steps.filter.outputs.python == 'true' || steps.filter.outputs.workflow == 'true'
+        id: targets
+        working-directory: pipelines
+        run: |
+          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+            DIRS=$(for d in */; do [ -f "$d/setup.py" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          else
+            DIRS=$(echo '${{ steps.filter.outputs.python_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+          fi
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          echo "Target Python pipelines: $DIRS"
       - name: Setup Python
-        if: steps.filter.outputs.python == 'true'
+        if: (steps.filter.outputs.python == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         uses: actions/setup-python@5fda3b95a4ea91299a34e894583c3862153e4b97 # v7.0.0
         with:
           python-version: '3.11'
       - name: Install pipenv
-        if: steps.filter.outputs.python == 'true'
+        if: (steps.filter.outputs.python == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         run: curl https://raw.githubusercontent.com/pypa/pipenv/master/get-pipenv.py | python
       - name: Python builds
-        if: steps.filter.outputs.python == 'true'
+        if: (steps.filter.outputs.python == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
         working-directory: pipelines
         run: |
           export PIPENV_VENV_IN_PROJECT=1
-          for pipeline_dir in */
+          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/setup.py" ]
@@ -246,19 +308,33 @@ jobs:
       - uses: dorny/paths-filter@ceb8a2b8f2d89434be7ff52d3de7ec3738c5cc9d # v4.0.3
         id: filter
         with:
+          list-files: json
           filters: |
+            workflow:
+              - '.github/workflows/pull_request.yml'
             docker:
               - 'pipelines/**/Dockerfile'
               - 'pipelines/**/*.py'
               - 'pipelines/**/requirements*.txt'
-              - '.github/workflows/pull_request.yml'
-      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
-        if: steps.filter.outputs.docker == 'true'
-      - name: Docker builds
-        if: steps.filter.outputs.docker == 'true'
+      - name: Detect target Docker containers
+        if: steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflow == 'true'
+        id: targets
         working-directory: pipelines
         run: |
-          for pipeline_dir in */
+          if [ "${{ steps.filter.outputs.workflow }}" = "true" ]; then
+            DIRS=$(for d in */; do [ -f "$d/Dockerfile" ] && echo "$d"; done | sed 's#/##' | tr '\n' ' ')
+          else
+            DIRS=$(echo '${{ steps.filter.outputs.docker_files }}' | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
+          fi
+          echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
+          echo "Target Docker containers: $DIRS"
+      - uses: docker/setup-buildx-action@37fe631027851001ddb9b187196cc803df7f5f0e # v4.3.0
+        if: (steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
+      - name: Docker builds
+        if: (steps.filter.outputs.docker == 'true' || steps.filter.outputs.workflow == 'true') && steps.targets.outputs.dirs != ''
+        working-directory: pipelines
+        run: |
+          for pipeline_dir in ${{ steps.targets.outputs.dirs }}
           do
             echo "Checking pipelines/$pipeline_dir"
             if [ -f "$pipeline_dir/Dockerfile" ]
@@ -269,7 +345,7 @@ jobs:
               echo -------------------------------------
               echo
               cd $pipeline_dir
-              mkdir gemma_2B && touch gemma_2B/DUMMY
+              mkdir -p gemma_2B && touch gemma_2B/DUMMY
               docker build -t github-actions .
               cd ..
             else


### PR DESCRIPTION
## Summary of Changes

Currently, the `Build and validation` workflow iterates over all pipelines and Dockerfiles (`for pipeline_dir in */`) and all Terraform modules (`ls -d */`) whenever any file matches a top-level category filter. For example, changing a single file in `pipelines/cdp/` triggers tests across all 5 Python pipelines and builds all 5 Docker container images (~7 minutes).

This PR makes CI execution intelligent and scoped:
- **Granular Path Extraction**: Uses `dorny/paths-filter` with `list-files: json` across all 5 jobs to dynamically extract only the specific subdirectories under `terraform/` and `pipelines/` modified in the PR.
- **Selective Iteration**:
  - `Terraform`: Runs `terraform init`, `terraform fmt -check`, and `terraform validate` only for touched modules.
  - `Java pipelines build`: Runs `./gradlew build` only for touched Java pipeline directories.
  - `Python PyLint Google style`: Runs `pylint` only for touched Python pipeline directories.
  - `Python pipelines build`: Runs `pipenv install`, source distribution build, and unit tests only for touched Python pipelines.
  - `Docker images build`: Builds Docker images only for touched pipeline directories containing a `Dockerfile`.
- **Fail-Safe Fallbacks**: If shared files change (`.github/workflows/pull_request.yml` or `pipelines/pylintrc`), the workflow automatically falls back to full regression validation across all components.
- **Branch Protection Compatible**: Retains the exact job names required by repository branch protection rules (`Terraform`, `Java pipelines build`, `Python PyLint Google style`, `Python pipelines build`, `Docker images build`).

## Testing & Verification
- Validated YAML syntax with Python `yaml.safe_load`.
- Ran simulation tests for path extraction covering single-pipeline, multi-pipeline, shared config, root docs, and empty change sets.