### PR TITLE
chore(renovate): limit Python version upgrades to 3.11, 3.12, or 3.13

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,25 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "packageRules": [
+    {
+      "description": "Limit Python versions to 3.11, 3.12, or 3.13 for Apache Beam and Dataflow compatibility",
+      "matchPackageNames": [
+        "python",
+        "docker.io/library/python",
+        "actions/python-versions"
+      ],
+      "allowedVersions": "/^(?:v?3\\.(?:11|12|13))(?:[.-]|$)/"
+    },
+    {
+      "description": "Limit Python versions to 3.11, 3.12, or 3.13 for Apache Beam and Dataflow compatibility",
+      "matchDepNames": [
+        "python",
+        "docker.io/library/python",
+        "actions/python-versions"
+      ],
+      "allowedVersions": "/^(?:v?3\\.(?:11|12|13))(?:[.-]|$)/"
+    }
   ]
 }


### PR DESCRIPTION
## Description

This PR updates the Renovate configuration in `renovate.json` to restrict automated Python dependency upgrades to versions 3.11, 3.12, or 3.13.

### Changes
- Configured `packageRules` in `renovate.json` matching `python`, `docker.io/library/python`, and `actions/python-versions`.
- Added `allowedVersions: "/^(?:v?3\\.(?:11|12|13))(?:[.-]|$)/"` to ensure only Python versions in the 3.11–3.13 range are proposed by Renovate.
- Prevents recurring PRs proposing upgrades to unsupported versions such as Python 3.14 (supersedes and addresses #241).

TAG=agy
CONV=bd1cef5e-a2ef-4aea-a83d-4bcdf8de1ca7