### PR TITLE
feat(terraform): revamp clickstream analytics infrastructure to lightweight pattern

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -28,7 +28,7 @@ dataflow-solution-guides/
 │   ├── cdp/                  # Pub/Sub topics, BigQuery dataset/tables, VPC
 │   ├── anomaly_detection/    # Pub/Sub, BigQuery, Vertex AI endpoints, VPC
 │   ├── marketing_intelligence/ # Pub/Sub topics, Firestore, BigQuery dataset, Artifact Registry, Service Account
-│   ├── clickstream_analytics/  # Bigtable instance/table, Pub/Sub, BigQuery, VPC
+│   ├── clickstream_analytics/  # Bigtable instance, Pub/Sub, BigQuery, Service Account
 │   ├── iot_analytics/        # Bigtable, Pub/Sub, GCS, VPC
 │   └── log_replication_splunk/ # Pub/Sub, Secret Manager, Service Account, Optional Splunk VM
 │

--- a/pipelines/clickstream_analytics_java/scripts/.gitignore
+++ b/pipelines/clickstream_analytics_java/scripts/.gitignore
@@ -1,0 +1,1 @@
+00_set_variables.sh

--- a/pipelines/clickstream_analytics_java/scripts/01_launch_pipeline.sh
+++ b/pipelines/clickstream_analytics_java/scripts/01_launch_pipeline.sh
@@ -1,8 +1,34 @@
+#!/usr/bin/env bash
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+SUBNET_OPT=""
+if [ -n "$SUBNETWORK" ]; then
+  SUBNET_OPT="--subnetwork=$SUBNETWORK"
+elif [ -n "$NETWORK" ]; then
+  SUBNET_OPT="--subnetwork=$NETWORK"
+fi
+
 ./gradlew run -Pargs="
   --runner=DataflowRunner \
-  --region=$REGION \
   --project=$PROJECT \
-  --gcpTempLocation=$TEMP_LOCATION \
+  --region=$REGION \
+  --tempLocation=$TEMP_LOCATION \
+  --serviceAccount=$SERVICE_ACCOUNT \
+  $SUBNET_OPT \
+  --usePublicIps=false \
+  --maxNumWorkers=$MAX_DATAFLOW_WORKERS \
   --bqProjectId=$PROJECT \
   --bqDataset=$BQ_DATASET \
   --bqTable=$BQ_TABLE \

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -13,7 +13,7 @@ This directory contains Terraform infrastructure definitions for each solution g
 | `cdp/` | Pub/Sub Topics (`transactions`, `coupon-redemption`), BigQuery Dataset, VPC, Subnet | `pipelines/cdp/` |
 | `anomaly_detection/` | Pub/Sub, BigQuery, Vertex AI Endpoint, VPC, Subnet | `pipelines/anomaly_detection/` |
 | `marketing_intelligence/` | Pub/Sub Topics (`input`, `output`), Cloud Firestore (Native Mode), BigQuery Dataset, Artifact Registry, Service Account | `pipelines/marketing_intelligence/` |
-| `clickstream_analytics/` | Cloud Bigtable (Instance & Table), Pub/Sub, BigQuery Dataset, VPC, Subnet | `pipelines/clickstream_analytics_java/` |
+| `clickstream_analytics/` | Cloud Bigtable (Instance & Table), Pub/Sub Topic, BigQuery Dataset, Service Account | `pipelines/clickstream_analytics_java/` |
 | `iot_analytics/` | Cloud Bigtable, Pub/Sub, GCS Bucket, VPC, Subnet | `pipelines/iot_analytics/` |
 | `log_replication_splunk/` | Pub/Sub Topics (`all-logs`, `deadletter-topic`), Cloud Logging Sink, Secret Manager (Splunk HEC token), Service Account, Optional Splunk Demo VM | `pipelines/log_replication_splunk/` |
 

--- a/terraform/TERRAFORM_REVAMP_GUIDE.md
+++ b/terraform/TERRAFORM_REVAMP_GUIDE.md
@@ -322,7 +322,7 @@ pylint --rcfile ../pylintrc .
 | :- | :--- | :--- | :--- | :--- |
 | 1 | **`etl_integration/`** *(Done)* | Spanner Instance/DBs/IAM, BigQuery Dataset | `spanner-cdc-dataflow-sa` | `pipelines/etl_integration_java/` |
 | 2 | **`cdp/`** | Pub/Sub Topics (`transactions`, `coupon_redemption`), BigQuery Dataset, Artifact Registry | `cdp-dataflow-sa` | `pipelines/cdp/` |
-| 3 | **`clickstream_analytics/`** | Cloud Bigtable (Instance & Table), Pub/Sub Topic, BigQuery Dataset & Tables | `clickstream-dataflow-sa` | `pipelines/clickstream_analytics_java/` |
+| 3 | **`clickstream_analytics/`** *(Done)* | Cloud Bigtable (Instance & Table), Pub/Sub Topic, BigQuery Dataset & Tables | `clickstream-dataflow-sa` | `pipelines/clickstream_analytics_java/` |
 | 4 | **`anomaly_detection/`** | Pub/Sub Topic, BigQuery Dataset, Vertex AI Endpoint | `anomaly-detection-sa` | `pipelines/anomaly_detection/` |
 | 5 | **`marketing_intelligence/`** *(Done)* | Pub/Sub Topics, BigQuery Dataset, Firestore Native, Artifact Registry | `marketing-intel-sa` | `pipelines/marketing_intelligence/` |
 | 6 | **`iot_analytics/`** | Cloud Bigtable, Pub/Sub Topics, GCS Bucket | `iot-analytics-sa` | `pipelines/iot_analytics/` |

--- a/terraform/clickstream_analytics/README.md
+++ b/terraform/clickstream_analytics/README.md
@@ -11,8 +11,8 @@ The scripts will create the following application-level resources:
 
 | Resource | Name | Description |
 | :--- | :---: | :--- |
-| **Pub/Sub topic** | `input` | The input Pub/Sub topic for streaming clickstream events. |
-| **Pub/Sub subscription** | `messages-sub` | The subscription to the `input` topic consumed by the Dataflow streaming pipeline. |
+| **Pub/Sub topic** | `dataflow-clickstream-input` | The input Pub/Sub topic for streaming clickstream events. |
+| **Pub/Sub subscription** | `dataflow-clickstream-input-sub` | The subscription to the input topic consumed by the Dataflow streaming pipeline. |
 | **Bigtable Instance** | `clickstream-analytics` | Cloud Bigtable instance to store enrichment metadata for incoming clickstream messages. |
 | **BigQuery Dataset** | `clickstream_analytics` | BigQuery dataset where processed records and dead-letter tables reside. |
 | **BigQuery Table** | `wikipedia` | Stores processed clickstream records from the Dataflow job. |

--- a/terraform/clickstream_analytics/README.md
+++ b/terraform/clickstream_analytics/README.md
@@ -1,94 +1,96 @@
 # Clickstream Analytics project deployment
 
-This directory contains the Terraform code to spawn a Google Cloud project
-with all the necessary infrastructure and configuration required for running
-the Clickstream Analytics solution guide.
+This directory contains the Terraform code to provision application-level infrastructure and configuration required for running the Clickstream Analytics solution guide on Google Cloud.
 
 These deployment scripts are part of the
 [Dataflow Clickstream Analytics solution guide](../../use_cases/Clickstream_Analytics.md).
 
 ## Bill of resources created by this script
 
-The scripts will create the following resources
+The scripts will create the following application-level resources:
 
-| Resource             |          Name           | Description                                                                                                                                                                                                                                 |
-| :------------------- | :---------------------: | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| Project              |       Set by user       | Optional, you may reuse an existing project. If the project is created by Terraform, it will enable the APIs for Cloud Build, Dataflow, Monitoring, Pub/Sub, Dataflow Autoscaling, and Artifact Registry                                    |
-| Bucket               |   Same as project id    | Using the standard storage class, this is a regional bucket in the region specified by the user.                                                                                                                                            |
-| Pub/Sub topic        |         `input`         | The input Pub/Sub topic for the sample pipeline.                                                                                                                                                                                            |
-| Pub/Sub subscription |     `messages-sub`      | The subscription to the `input` topic that is actually used by the Dataflow pipeline.                                                                                                                                                       |
-| Service account      |    `my-dataflow-sa`     | Dataflow worker servive account. It has storage admin, Dataflow worker, metrics writer and Pub/Sub editor roles assigned at project level.                                                                                                  |
-| VPC network          |     `dataflow-net`      | If the project is created from scratch, the default network is removed and this network is re-created with a single regional sub-network.                                                                                                   |
-| Cloud NAT            |     `dataflow-nat`      | Cloud NAT in the region specified by the user, in case the Dataflow workers need to reach the Internet. This is not necessary for the sample pipeline provided.                                                                             |
-| Bigtable Instance    | `clickstream-analytics` | BigTable instance to store the information for enrichment of incoming messages                                                                                                                                                              |
-| BigQuery Dataset     | `clickstream_analytics` | BigQuery dataset where the tables will be created.                                                                                                                                                                                          |
-| BigQuery Table       |       `wikipedia`       | Store the processed records from dataflow job.                                                                                                                                                                                              |
-| BigQuery Table       |      `deadletter`       | Table for all the records that cannot be parsed, it contains more details about the error found processing each record.                                                                                                                     |
-| Firewall rules       |      Several rules      | Ingress and egress rules to remove unnecessary traffic, and to ensure the traffice required by Dataflow. If you want to access a VM using SSH, apply the network tag `ssh` to that instance. Same for `http-server` and for `https-server`. |
+| Resource | Name | Description |
+| :--- | :---: | :--- |
+| **Pub/Sub topic** | `input` | The input Pub/Sub topic for streaming clickstream events. |
+| **Pub/Sub subscription** | `messages-sub` | The subscription to the `input` topic consumed by the Dataflow streaming pipeline. |
+| **Bigtable Instance** | `clickstream-analytics` | Cloud Bigtable instance to store enrichment metadata for incoming clickstream messages. |
+| **BigQuery Dataset** | `clickstream_analytics` | BigQuery dataset where processed records and dead-letter tables reside. |
+| **BigQuery Table** | `wikipedia` | Stores processed clickstream records from the Dataflow job. |
+| **BigQuery Table** | `deadletter` | Stores failed/unparseable records with full payload and error stacktrace for debugging. |
+| **Service account** | `clickstream-dataflow-sa` (configurable) | Dedicated Dataflow worker service account with least-privilege roles (`roles/storage.objectAdmin`, `roles/dataflow.worker`, `roles/monitoring.metricWriter`, `roles/pubsub.editor`, `roles/bigtable.reader`, `roles/bigquery.dataEditor`, `roles/bigquery.jobUser`). |
+| **GCS Bucket** *(Optional)* | `var.bucket_name` or `var.project_id` | Optional regional standard GCS bucket for Dataflow temp/staging files (created when `create_bucket = true`). |
 
 ## Configuration variables
 
 This deployment accepts the following configuration variables:
 
-| Variable                |   Type    | Description                                                                                                                                                                                            |
-| :---------------------- | :-------: | :----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `billing_account`       | `string`  | Optional. Billing account to be used if the project is created from scratch.                                                                                                                           |
-| `organization`          | `string`  | Optional. Organization (or folder) number, where the project will be created. Only required if you are creating the project from scratch. Use the format `organizations/XXXXXXX` or `folder/XXXXXXXX`. |
-| `project_create`        | `boolean` | Set to false to reuse an existing project. Or to true to create a new project from scratch.                                                                                                            |
-| `project_id`            | `string`  | Project Id.                                                                                                                                                                                            |
-| `region`                | `string`  | Region to be used for all the resources. The VPC will contain only a single sub-network in this region.                                                                                                |
-| `destroy_all_resources` |  `bool`   | Optional. Default true. Destroy buckets and the Spanner instance with `tf destroy`.                                                                                                                    |
-| `network-prefix`        | `string`  | Optional. Default "dataflow". Add a prefix to the network net, subnet, NAT                                                                                                                             |
-
-The default values of all the optional configuration variables are set for development projects.
-**For a production project, you should change `destroy_all_resources` to false.**
+| Variable | Type | Default | Description |
+| :--- | :---: | :---: | :--- |
+| `project_id` | `string` | *(Required)* | Existing GCP project ID where resources and IAM roles will be provisioned. |
+| `region` | `string` | *(Required)* | GCP region for Bigtable, BigQuery dataset, Pub/Sub, and Dataflow resources (e.g. `us-central1` or `europe-southwest1`). |
+| `subnetwork` | `string` | `null` | Optional subnetwork URL or path for Dataflow workers (e.g. `regions/europe-southwest1/subnetworks/dev-default` or full Shared VPC URI). If omitted, the default network is used. |
+| `bucket_name` | `string` | `null` | Optional GCS bucket name for Dataflow temp/staging files. Defaults to `project_id` if not specified. |
+| `service_account_name` | `string` | `"clickstream-dataflow-sa"` | Name of the dedicated Dataflow worker service account to create. |
+| `create_bucket` | `bool` | `false` | Set to `true` to provision a new GCS bucket, or `false` to reuse an existing bucket. |
+| `destroy_all_resources` | `bool` | `true` | When `true`, enables deletion of Bigtable instances and BigQuery dataset contents on `terraform destroy`. For production environments, set to `false`. |
 
 ## How to deploy
 
-1. **Set the configuration variables:**
+1. **Set configuration variables:**
 
-   - Create a file named `terraform.tfvars` in the current directory.
-   - Add the following configuration variables to the file, replacing the values with your own:
+   Create a file named `terraform.tfvars` in this directory:
 
-     ```bash
-     billing_account = "YOUR_BILLING_ACCOUNT"
-     organization = "YOUR_ORGANIZATION_ID"
-     project_create = TRUE_OR_FALSE
-     project_id = "YOUR_PROJECT_ID"
-     region = "YOUR_REGION"
-     ```
+   **Standard Deployment (Default Network / Same Project):**
+   ```hcl
+   project_id            = "YOUR_PROJECT_ID"
+   region                = "us-central1"
+   destroy_all_resources = true
+   ```
 
-   - If this is a production deployment, make sure you change also the optional variables.
+   **Shared VPC Deployment (Dataflow in Service Project, Network in Host Project):**
+   ```hcl
+   project_id            = "YOUR_PROJECT_ID"
+   region                = "europe-southwest1"
+   subnetwork            = "https://www.googleapis.com/compute/v1/projects/HOST_PROJECT_ID/regions/europe-southwest1/subnetworks/shared-dataflow-subnet"
+   bucket_name           = "YOUR_BUCKET_NAME"
+   create_bucket         = false
+   service_account_name  = "clickstream-dataflow-sa"
+   destroy_all_resources = true
+   ```
 
 2. **Initialize Terraform:**
-
-   - Run the following command to initialize Terraform:
-
-     ```bash
-     terraform init
-     ```
+   ```bash
+   terraform init
+   ```
 
 3. **Apply the configuration:**
+   ```bash
+   terraform plan -out=tfplan
+   terraform apply tfplan
+   ```
 
-   - Run the following command to apply the Terraform configuration:
+4. **Access the deployed resources:**
+   Terraform will automatically generate `pipelines/clickstream_analytics_java/scripts/00_set_variables.sh` with all required environment variables.
 
-     ```bash
-     terraform apply
-     ```
+## Scripts generation
 
-4. **Wait for the deployment to complete:**
-   - Terraform will output the status of the deployment. Wait for it to complete successfully.
-5. **Access the deployed resources:** You are now ready to launch the sample pipeline in this
-   solution guide.
+The Terraform code will generate an environment configuration script with all variable values to be used by the pipeline:
+
+```bash
+source ../../pipelines/clickstream_analytics_java/scripts/00_set_variables.sh
+```
 
 ## How to remove
 
-The setup will be continuously consuming as this is a streaming architecture, running without stop.
+To destroy all provisioned infrastructure:
 
-**BEWARE: THE COMMAND BELOW WILL DESTROY AND REMOVE ALL THE RESOURCES**.
+1. Cancel any active Dataflow streaming jobs first:
+   ```bash
+   gcloud dataflow jobs list --region=YOUR_REGION --status=active
+   gcloud dataflow jobs cancel JOB_ID --region=YOUR_REGION
+   ```
 
-To destroy and stop all the resources, run:
-
-```bash
-terraform destroy
-```
+2. Run `terraform destroy`:
+   ```bash
+   terraform destroy
+   ```

--- a/terraform/clickstream_analytics/main.tf
+++ b/terraform/clickstream_analytics/main.tf
@@ -1,4 +1,4 @@
-#  Copyright 2025 Google LLC
+#  Copyright 2026 Google LLC
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -13,33 +13,48 @@
 #  limitations under the License.
 
 locals {
-  dataflow_service_account = "my-dataflow-sa"
+  dataflow_service_account = var.service_account_name != null ? var.service_account_name : "clickstream-dataflow-sa"
   bigtable_instance        = "clickstream-analytics"
   bigtable_zone            = "${var.region}-a"
   bigtable_lookup_key      = "bigtable-lookup-key"
   bigquery_dataset         = "clickstream_analytics"
+  bigquery_table           = "wikipedia"
+  bigquery_deadletter      = "deadletter"
+  bucket_name              = var.bucket_name != null ? var.bucket_name : var.project_id
+  worker_type              = "n2-standard-4"
+  max_dataflow_workers     = 10
 }
 
-
-// Project
-module "google_cloud_project" {
-  source          = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/project?ref=v57.0.0"
-  billing_account = var.billing_account
-  project_reuse   = var.project_create ? null : {}
-  name            = var.project_id
-  parent          = var.organization
-  services = [
-    "dataflow.googleapis.com",
-    "monitoring.googleapis.com",
-    "pubsub.googleapis.com",
-    "autoscaling.googleapis.com",
-    "bigtableadmin.googleapis.com",
-    "bigquery.googleapis.com"
-  ]
+// Enable required Google Cloud APIs
+resource "google_project_service" "dataflow" {
+  project            = var.project_id
+  service            = "dataflow.googleapis.com"
+  disable_on_destroy = false
 }
 
-resource "google_bigtable_instance" "clickstream-analytics" {
-  name = local.bigtable_instance
+resource "google_project_service" "pubsub" {
+  project            = var.project_id
+  service            = "pubsub.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "bigquery" {
+  project            = var.project_id
+  service            = "bigquery.googleapis.com"
+  disable_on_destroy = false
+}
+
+resource "google_project_service" "bigtable" {
+  project            = var.project_id
+  service            = "bigtableadmin.googleapis.com"
+  disable_on_destroy = false
+}
+
+// Cloud Bigtable instance for real-time clickstream enrichment
+resource "google_bigtable_instance" "clickstream_analytics" {
+  name                = local.bigtable_instance
+  project             = var.project_id
+  deletion_protection = !var.destroy_all_resources
 
   cluster {
     cluster_id   = "${local.bigtable_instance}-c1"
@@ -47,20 +62,40 @@ resource "google_bigtable_instance" "clickstream-analytics" {
     storage_type = "HDD"
     zone         = local.bigtable_zone
   }
+
+  depends_on = [
+    google_project_service.bigtable
+  ]
 }
 
-# Create BigQuery dataset
-resource "google_bigquery_dataset" "clickstream_analytics" {
-  dataset_id  = local.bigquery_dataset
-  description = "Dataset for storing clickstream analytics data"
-  location    = var.region
+// BigQuery dataset for processed clickstream and deadletter data
+module "dataset" {
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/bigquery-dataset?ref=v57.0.0"
+  project_id = var.project_id
+  id         = local.bigquery_dataset
+  location   = var.region
+  access = {
+    dataflow-writer = { role = "OWNER", type = "user" }
+  }
+  access_identities = {
+    dataflow-writer = module.dataflow_sa.email
+  }
+
+  options = {
+    delete_contents_on_destroy = var.destroy_all_resources
+  }
+
+  depends_on = [
+    google_project_service.bigquery
+  ]
 }
 
-# Create BigQuery table
+// BigQuery destination table for processed wikipedia clickstream data
 resource "google_bigquery_table" "wikipedia" {
-  dataset_id          = google_bigquery_dataset.clickstream_analytics.dataset_id
-  table_id            = "wikipedia"
-  deletion_protection = false
+  project             = var.project_id
+  dataset_id          = module.dataset.dataset_id
+  table_id            = local.bigquery_table
+  deletion_protection = !var.destroy_all_resources
 
   schema = jsonencode([
     { name = "prev", type = "STRING", mode = "NULLABLE" },
@@ -70,10 +105,12 @@ resource "google_bigquery_table" "wikipedia" {
   ])
 }
 
+// BigQuery dead-letter table for unparseable or failed records
 resource "google_bigquery_table" "deadletter" {
-  dataset_id          = google_bigquery_dataset.clickstream_analytics.dataset_id
-  table_id            = "deadletter"
-  deletion_protection = false
+  project             = var.project_id
+  dataset_id          = module.dataset.dataset_id
+  table_id            = local.bigquery_deadletter
+  deletion_protection = !var.destroy_all_resources
 
   schema = jsonencode([
     { name = "timestamp", type = "TIMESTAMP", mode = "REQUIRED" },
@@ -90,107 +127,84 @@ resource "google_bigquery_table" "deadletter" {
   ])
 }
 
-// Buckets for staging data, scripts, etc, in the two regions
+// Optional GCS Bucket for staging & temp location
 module "buckets" {
+  count         = var.create_bucket ? 1 : 0
   source        = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/gcs?ref=v57.0.0"
-  project_id    = module.google_cloud_project.project_id
-  name          = module.google_cloud_project.project_id
+  project_id    = var.project_id
+  name          = local.bucket_name
   location      = var.region
   storage_class = "STANDARD"
   force_destroy = var.destroy_all_resources
 }
 
+// Pub/Sub input topic and subscription
 module "input_topic" {
   source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
+  project_id = var.project_id
   name       = "input"
   subscriptions = {
     messages-sub = {}
   }
-}
 
-// Service account
-module "dataflow_sa" {
-  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/iam-service-account?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
-  name       = local.dataflow_service_account
-  iam_project_roles = {
-    (module.google_cloud_project.project_id) = [
-      "roles/storage.admin",
-      "roles/dataflow.worker",
-      "roles/monitoring.metricWriter",
-      "roles/pubsub.editor",
-      "roles/bigtable.reader"
-    ]
-  }
-}
-
-// Network
-module "vpc_network" {
-  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/net-vpc?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
-  name       = "${var.network_prefix}-net"
-  subnets = [
-    {
-      ip_cidr_range         = "10.1.0.0/16"
-      name                  = "${var.network_prefix}-subnet"
-      region                = var.region
-      enable_private_access = true
-      secondary_ip_ranges = {
-        pods     = { ip_cidr_range = "10.16.0.0/14" }
-        services = { ip_cidr_range = "10.20.0.0/24" }
-      }
-    }
+  depends_on = [
+    google_project_service.pubsub
   ]
 }
 
-module "firewall_rules" {
-  // Default rules for internal traffic + SSH access via IAP
-  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/net-vpc-firewall?ref=v57.0.0"
-  project_id = module.google_cloud_project.project_id
-  network    = module.vpc_network.name
-  default_rules_config = {
-    admin_ranges = [
-      module.vpc_network.subnet_ips["${var.region}/${var.network_prefix}-subnet"],
+// Dedicated Dataflow Worker Service Account
+module "dataflow_sa" {
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/iam-service-account?ref=v57.0.0"
+  project_id = var.project_id
+  name       = local.dataflow_service_account
+  iam_project_roles = {
+    (var.project_id) = [
+      "roles/storage.objectAdmin",
+      "roles/dataflow.worker",
+      "roles/monitoring.metricWriter",
+      "roles/pubsub.editor",
+      "roles/bigtable.reader",
+      "roles/bigquery.dataEditor",
+      "roles/bigquery.jobUser"
     ]
-  }
-  egress_rules = {
-    allow-egress-dataflow = {
-      deny        = false
-      description = "Dataflow firewall rule egress"
-      targets     = ["dataflow"]
-      rules       = [{ protocol = "tcp", ports = [12345, 12346] }]
-    }
-  }
-  ingress_rules = {
-    allow-ingress-dataflow = {
-      description = "Dataflow firewall rule ingress"
-      targets     = ["dataflow"]
-      rules       = [{ protocol = "tcp", ports = [12345, 12346] }]
-    }
   }
 }
 
+// Grant networkUser role on the subnetwork to the Dataflow worker service account (supports Shared VPC and local subnets)
+resource "google_compute_subnetwork_iam_member" "dataflow_network_user" {
+  count      = var.subnetwork != null ? 1 : 0
+  project    = length(regexall("projects/([^/]+)/", var.subnetwork)) > 0 ? regex("projects/([^/]+)/", var.subnetwork)[0] : var.project_id
+  region     = length(regexall("regions/([^/]+)/", var.subnetwork)) > 0 ? regex("regions/([^/]+)/", var.subnetwork)[0] : var.region
+  subnetwork = length(regexall("subnetworks/([^/]+)", var.subnetwork)) > 0 ? regex("subnetworks/([^/]+)", var.subnetwork)[0] : var.subnetwork
+  role       = "roles/compute.networkUser"
+  member     = module.dataflow_sa.iam_email
+}
+
+// Script with variables to launch the Dataflow jobs
 resource "local_file" "variables_script" {
   filename        = "${path.module}/../../pipelines/clickstream_analytics_java/scripts/00_set_variables.sh"
   file_permission = "0644"
   content         = <<FILE
 # This file is generated by the Terraform code of this Solution Guide.
 # We recommend that you modify this file only through the Terraform deployment.
-export PROJECT=${module.google_cloud_project.project_id}
+export PROJECT=${var.project_id}
 export REGION=${var.region}
-export SUBNETWORK=regions/${var.region}/subnetworks/${var.network_prefix}-subnet
-export TEMP_LOCATION=gs://$PROJECT/tmp
+export SUBNETWORK=${var.subnetwork != null ? var.subnetwork : ""}
+export NETWORK=$${SUBNETWORK}
+export TEMP_LOCATION=gs://${local.bucket_name}/tmp
 export SERVICE_ACCOUNT=${module.dataflow_sa.email}
 
-export BQ_DATASET=${google_bigquery_dataset.clickstream_analytics.dataset_id}
+export BQ_DATASET=${module.dataset.dataset_id}
 export BQ_TABLE=${google_bigquery_table.wikipedia.table_id}
 export BQ_DEADLETTER_TABLE=${google_bigquery_table.deadletter.table_id}
 
 export SUBSCRIPTION=${module.input_topic.subscriptions["messages-sub"].id}
 
-export BIGTABLE_INSTANCE=${google_bigtable_instance.clickstream-analytics.id}
+export BIGTABLE_INSTANCE=${google_bigtable_instance.clickstream_analytics.name}
 export BIGTABLE_TABLE=$BQ_TABLE
 export BT_LOOKUP_KEY=${local.bigtable_lookup_key}
+
+export MAX_DATAFLOW_WORKERS=${local.max_dataflow_workers}
+export WORKER_TYPE=${local.worker_type}
 FILE
 }

--- a/terraform/clickstream_analytics/main.tf
+++ b/terraform/clickstream_analytics/main.tf
@@ -14,6 +14,8 @@
 
 locals {
   dataflow_service_account = var.service_account_name != null ? var.service_account_name : "clickstream-dataflow-sa"
+  pubsub_topic             = "dataflow-clickstream-input"
+  pubsub_subscription      = "dataflow-clickstream-input-sub"
   bigtable_instance        = "clickstream-analytics"
   bigtable_zone            = "${var.region}-a"
   bigtable_lookup_key      = "bigtable-lookup-key"
@@ -142,9 +144,9 @@ module "buckets" {
 module "input_topic" {
   source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v57.0.0"
   project_id = var.project_id
-  name       = "input"
+  name       = local.pubsub_topic
   subscriptions = {
-    messages-sub = {}
+    (local.pubsub_subscription) = {}
   }
 
   depends_on = [
@@ -198,7 +200,8 @@ export BQ_DATASET=${module.dataset.dataset_id}
 export BQ_TABLE=${google_bigquery_table.wikipedia.table_id}
 export BQ_DEADLETTER_TABLE=${google_bigquery_table.deadletter.table_id}
 
-export SUBSCRIPTION=${module.input_topic.subscriptions["messages-sub"].id}
+export TOPIC=${module.input_topic.id}
+export SUBSCRIPTION=${module.input_topic.subscriptions[local.pubsub_subscription].id}
 
 export BIGTABLE_INSTANCE=${google_bigtable_instance.clickstream_analytics.name}
 export BIGTABLE_TABLE=$BQ_TABLE

--- a/terraform/clickstream_analytics/variables.tf
+++ b/terraform/clickstream_analytics/variables.tf
@@ -1,4 +1,4 @@
-#  Copyright 2025 Google LLC
+#  Copyright 2026 Google LLC
 #
 #  Licensed under the Apache License, Version 2.0 (the "License");
 #  you may not use this file except in compliance with the License.
@@ -12,41 +12,42 @@
 #  See the License for the specific language governing permissions and
 #  limitations under the License.
 
-variable "billing_account" {
-  description = "Billing account for the projects/resources"
-  type        = string
-  default     = null
-}
-
-variable "destroy_all_resources" {
-  description = "Destroy all resources when calling tf destroy. Use false for production deployments. For test environments, set to true to remove all buckets and Spanner instances."
-  type        = bool
-  default     = true
-}
-
-variable "network_prefix" {
-  description = "Prefix to be used for networks and subnetworks"
-  type        = string
-  default     = "dataflow"
-}
-
-variable "organization" {
-  description = "Organization for the project/resources"
-  type        = string
-  default     = null
-}
-
-variable "project_create" {
-  description = "True if you want to create a new project. False to reuse an existing project."
-  type        = bool
-}
-
 variable "project_id" {
-  description = "Project ID for the project/resources"
+  description = "Project ID of the existing GCP project where resources will be provisioned."
   type        = string
 }
 
 variable "region" {
-  description = "The region for resources and networking"
+  description = "The GCP region for Bigtable, BigQuery dataset, Pub/Sub, and Dataflow resources."
   type        = string
+}
+
+variable "subnetwork" {
+  description = "Optional subnetwork URL or path for Dataflow workers (e.g. regions/europe-southwest1/subnetworks/dev-default or full URI). If omitted, the default network is used."
+  type        = string
+  default     = null
+}
+
+variable "bucket_name" {
+  description = "Optional GCS bucket name for Dataflow temp/staging files. Defaults to project_id if not specified."
+  type        = string
+  default     = null
+}
+
+variable "create_bucket" {
+  description = "Whether to create a new GCS bucket for temp/staging files. Set to false if using an existing bucket."
+  type        = bool
+  default     = false
+}
+
+variable "service_account_name" {
+  description = "Name of the dedicated Dataflow worker service account to create."
+  type        = string
+  default     = "clickstream-dataflow-sa"
+}
+
+variable "destroy_all_resources" {
+  description = "Destroy all resources when calling tf destroy. Use false for production deployments. For test environments, set to true to remove all resources."
+  type        = bool
+  default     = true
 }

--- a/use_cases/Clickstream_Analytics.md
+++ b/use_cases/Clickstream_Analytics.md
@@ -13,7 +13,7 @@ For the full version of this solution guide, please refer to:
 
 ## Assets included in this repository
 
-- [Terraform code to deploy a project for Clickstream Analytics](../terraform/clickstream_analytics/)
+- [Terraform code to deploy infrastructure for Clickstream Analytics](../terraform/clickstream_analytics/)
 - [Sample pipeline in Java for clickstream analytics with Dataflow](../pipelines/clickstream_analytics_java/)
 
 ## Technical benefits


### PR DESCRIPTION
## Description
Upgrades the Terraform infrastructure and pipeline launch scripts for the **Clickstream Analytics** solution guide in accordance with `terraform/TERRAFORM_REVAMP_GUIDE.md`.

### Key Changes
- **Lightweight Architecture**: Removed monolithic project, VPC network, and firewall modules. Terraform now provisions application-level resources directly into existing projects and networks (e.g. Shared VPC).
- **Standard Variables**: Standardized `variables.tf` (`project_id`, `region`, `subnetwork`, `bucket_name`, `service_account_name`, `create_bucket`, `destroy_all_resources`).
- **Declarative API Enablement**: Added `google_project_service` for Dataflow, Bigtable, BigQuery, and Pub/Sub.
- **Dedicated Service Account & Least-Privilege IAM**: Configured `clickstream-dataflow-sa` with role bindings for Dataflow worker, Bigtable reader, BigQuery data editor/job user, Pub/Sub editor, and Storage object admin.
- **Automated Subnetwork IAM**: Added `google_compute_subnetwork_iam_member.dataflow_network_user` to grant `roles/compute.networkUser` on the worker subnet (supports Shared VPC and local subnets).
- **Domain-Specific Resource Names**: Renamed generic Pub/Sub topic and subscription to `dataflow-clickstream-input` and `dataflow-clickstream-input-sub` to avoid collisions in shared projects.
- **Pipeline Runner Guardrails**: Updated `pipelines/clickstream_analytics_java/scripts/01_launch_pipeline.sh` to inject `$SUBNET_OPT`, `--serviceAccount=$SERVICE_ACCOUNT`, `--usePublicIps=false`, and `--maxNumWorkers=$MAX_DATAFLOW_WORKERS`.
- **Documentation**: Updated `terraform/clickstream_analytics/README.md`, `use_cases/Clickstream_Analytics.md`, `AGENTS.md`, and marked Clickstream Analytics as done in `terraform/TERRAFORM_REVAMP_GUIDE.md`.

### Validation
- `terraform fmt -check` passed.
- `terraform validate` passed.
- Java pipeline build and Spotless check passed (`./gradlew spotlessApply build`).
- Successfully deployed to live GCP project `ihr-pipelines` in `europe-southwest1` with Shared VPC, followed by clean `terraform destroy` teardown.

TAG=agy
CONV=a0231017-370b-4bae-a9e3-2f2d4b1bfa3d