### PR TITLE
ci: enable linting and validation for auxiliary Python code in CI

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -220,7 +220,7 @@ jobs:
           if [ "$IS_SHARED" = "true" ]; then
             DIRS=""
             for d in */; do
-              if [ -f "$d/setup.py" ]; then
+              if [ -d "$d" ] && [ -n "$(find "$d" -name "*.py" -not -path "*/.*" 2>/dev/null)" ]; then
                 DIRS="$DIRS ${d%/}"
               fi
             done
@@ -252,7 +252,7 @@ jobs:
           for pipeline_dir in $TARGET_DIRS
           do
             echo "Checking pipelines/$pipeline_dir"
-            if [ -f "$pipeline_dir/setup.py" ]
+            if [ -d "$pipeline_dir" ] && [ -n "$(find "$pipeline_dir" -name "*.py" -not -path "*/.*" 2>/dev/null)" ]
             then
               echo
               echo -------------------------------------
@@ -260,10 +260,10 @@ jobs:
               echo -------------------------------------
               echo
               cd "$pipeline_dir"
-              pylint --rcfile ../pylintrc .
+              pylint --rcfile ../pylintrc --ignore=.venv,venv,.gradle,build,bin,third_party .
               cd ..
             else
-              echo Ignoring, no Python pipeline found
+              echo "Ignoring, no Python files found in $pipeline_dir"
             fi
           done
   python-build:
@@ -298,7 +298,7 @@ jobs:
           if [ "$IS_WORKFLOW" = "true" ]; then
             DIRS=""
             for d in */; do
-              if [ -f "$d/setup.py" ]; then
+              if [ -d "$d" ] && [ -n "$(find "$d" \( -name "*.py" -o -name "requirements*.txt" \) -not -path "*/.*" 2>/dev/null)" ]; then
                 DIRS="$DIRS ${d%/}"
               fi
             done
@@ -329,11 +329,13 @@ jobs:
           for pipeline_dir in $TARGET_DIRS
           do
             echo "Checking pipelines/$pipeline_dir"
-            if [ -f "$pipeline_dir/setup.py" ]
+            HAS_PY=$(find "$pipeline_dir" -name "*.py" -not -path "*/.*" 2>/dev/null | head -n 1)
+            HAS_REQ=$(find "$pipeline_dir" -name "requirements*.txt" -not -path "*/.*" 2>/dev/null | head -n 1)
+            if [ -f "$pipeline_dir/setup.py" ] || [ -n "$HAS_PY" ] || [ -n "$HAS_REQ" ]
             then
               echo
               echo -------------------------------------
-              echo Building "$pipeline_dir"
+              echo Building / checking "$pipeline_dir"
               echo -------------------------------------
               echo
               cd "$pipeline_dir"
@@ -343,23 +345,32 @@ jobs:
               fi
               echo "Using Python $PY_VER for $pipeline_dir"
               pipenv --python "$PY_VER" install
-              for req_txt in requirements*.txt
-              do
+              while IFS= read -r req_txt; do
                 if [ -s "$req_txt" ]; then
-                  echo ----- Installing dependencies in "$req_txt" -----
+                  echo "----- Installing dependencies in $req_txt -----"
                   pipenv install -r "$req_txt"
                 fi
-              done
-              pipenv run pip install setuptools
-              echo ----- Building package -----
-              pipenv run python setup.py sdist
+              done < <(find . -name "requirements*.txt" -not -path "*/.*" -type f | sort)
+              if [ -f "setup.py" ]; then
+                pipenv run pip install setuptools
+                echo "----- Building package -----"
+                pipenv run python setup.py sdist
+              else
+                echo "No setup.py found, skipping package sdist build"
+              fi
               if [ -d "tests" ]; then
-                echo ----- Running unit tests -----
+                echo "----- Running unit tests in tests/ -----"
                 pipenv run python -m unittest discover tests
               fi
+              if [ -d "scripts/tests" ]; then
+                echo "----- Running unit tests in scripts/tests/ -----"
+                pipenv run python -m unittest discover scripts/tests
+              fi
+              echo "----- Verifying Python compilation syntax -----"
+              pipenv run python -m compileall -q .
               cd ..
             else
-              echo Ignoring, no Python pipeline found
+              echo "Ignoring, no Python code or dependencies found in $pipeline_dir"
             fi
           done
   docker-build:
@@ -398,8 +409,14 @@ jobs:
             done
             DIRS="${DIRS# }"
           else
-            DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u | tr '\n' ' ')
-            DIRS="${DIRS% }"
+            RAW_DIRS=$(echo "$FILES_JSON" | jq -r '.[] | select(startswith("pipelines/")) | split("/") | select(length > 2) | .[1]' | sort -u)
+            DIRS=""
+            for d in $RAW_DIRS; do
+              if [ -f "$d/Dockerfile" ]; then
+                DIRS="$DIRS $d"
+              fi
+            done
+            DIRS="${DIRS# }"
           fi
           echo "dirs=$DIRS" >> "$GITHUB_OUTPUT"
           echo "Target Docker containers: $DIRS"

--- a/pipelines/pylintrc
+++ b/pipelines/pylintrc
@@ -8,7 +8,7 @@
 [MAIN]
 
 # Files or directories to be skipped. They should be base names, not paths.
-ignore=third_party
+ignore=third_party,.venv,venv,.gradle,build,bin
 
 # Files or directories matching the regex patterns are skipped. The regex
 # matches against base names, not paths.


### PR DESCRIPTION
## Summary
Fixes the Pull Request CI workflow (`.github/workflows/pull_request.yml`) to ensure all Python code across the repository—including auxiliary scripts in Java pipelines (e.g. data generators and Bigtable population scripts as seen in #254)—is fully linted, tested, and validated.

### Problem
Previously, both `pylint-google-style` and `python-build` jobs strictly required the presence of `setup.py` (`if [ -f "$pipeline_dir/setup.py" ]`). For Java pipelines that contain auxiliary Python scripts (like `pipelines/clickstream_analytics_java/scripts/`), both jobs silently skipped them with `Ignoring, no Python pipeline found`. This allowed lint errors (`line-too-long`, `unused-import`) and untracked dependency issues to slip past CI undetected.

### Solution
1. **`pylint-google-style`**:
   - Updated directory detection to target any pipeline directory containing `.py` files.
   - Updated `Run pylint` to check for `.py` files rather than `setup.py`, running `pylint --rcfile ../pylintrc --ignore=.venv,venv,.gradle,build,bin,third_party .`.
2. **`python-build`**:
   - Updated directory detection to target directories with `.py` or `requirements*.txt` files.
   - Recursively discovers and installs dependencies from all `requirements*.txt` files (including nested ones like `scripts/requirements.txt`).
   - Gated package distribution (`sdist`) on `setup.py` existence, skipping it cleanly for auxiliary scripts while still running `unittest` and bytecode compilation syntax verification (`python -m compileall -q .`).
3. **`docker-build`**:
   - Filtered target directories to only those that contain a `Dockerfile`, avoiding superfluous `setup-buildx` setup on Java pipelines touching Python scripts.
4. **`pipelines/pylintrc`**:
   - Added `.venv,venv,.gradle,build,bin` to the ignore list in `[MAIN]`.

### Verification
- Validated YAML syntax in `.github/workflows/pull_request.yml`.
- Verified all 5 existing Python pipelines on `main` score 10.00/10 with 0 lint errors.
- Verified against `pipelines/clickstream_analytics_java/scripts/` from #254: both jobs now correctly target the directory and surface violations rather than skipping.
- Verified that clean Java pipelines (e.g. `etl_integration_java`) are cleanly skipped.

TAG=agy
CONV=d15efcd8-2deb-4d46-8555-f8beafed4b74