### PR TITLE
feat(terraform): add gaming analytics solution guide infrastructure

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,8 @@ dataflow-solution-guides/
 │   ├── Marketing_Intelligence.md # Real-time marketing intelligence with Firestore & Scikit-Learn RunInference
 │   ├── Clickstream_Analytics.md  # Real-time clickstream analytics with Bigtable enrichment
 │   ├── IoT_Analytics.md      # Real-time IoT analytics with Bigtable & Scikit-Learn RunInference
-│   └── Log_replication.md    # Real-time log replication into Splunk
+│   ├── Log_replication.md    # Real-time log replication into Splunk
+│   └── Gaming_Analytics.md   # Real-time gaming analytics with Bigtable enrichment & in-game activation
 │
 ├── terraform/                # Infrastructure-as-Code using Google Cloud Foundation Fabric
 │   ├── ml_ai/                # Pub/Sub topics, Artifact Registry, GCS bucket, Service Account
@@ -30,7 +31,8 @@ dataflow-solution-guides/
 │   ├── marketing_intelligence/ # Pub/Sub topics, Firestore, BigQuery dataset, Artifact Registry, Service Account
 │   ├── clickstream_analytics/  # Bigtable instance, Pub/Sub, BigQuery, Service Account
 │   ├── iot_analytics/        # Bigtable, Pub/Sub, BigQuery, Artifact Registry, Service Account
-│   └── log_replication_splunk/ # Pub/Sub, Secret Manager, Service Account, Optional Splunk VM
+│   ├── log_replication_splunk/ # Pub/Sub, Secret Manager, Service Account, Optional Splunk VM
+│   └── gaming_analytics/     # Pub/Sub in/out/dead-letter, Bigtable feature store, BigQuery, Artifact Registry, Service Account
 │
 ├── pipelines/                # Apache Beam streaming pipeline implementations
 │   ├── ml_ai_python/         # Python: Beam RunInference with Gemma 4 using vLLM on NVIDIA L4 GPU

--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ This the list of solution guides available at this moment:
 |          [IoT Analytics](./use_cases/IoT_Analytics.md)          |    Real-time Internet of Things (IoT) analytics with Bigtable enrichment & Scikit-Learn RunInference    | Ready :white_check_mark:  |
 |      [Anomaly Detection](./use_cases/Anomaly_Detection.md)      |         Real-time anomaly detection with Bigtable enrichment & models deployed in Vertex AI             | Ready :white_check_mark:  |
 |          [Customer Data Platform](./use_cases/CDP.md)           |          Real-time customer data platform that unifies a customer view from different sources.          | Ready :white_check_mark:  |
-|       [Gaming Analytics](./use_cases/gaming_analytics.md)       |               Real-time analyis of gaming data to enhance live gameplay & offer targeting               |      Beta :factory:       |
+|       [Gaming Analytics](./use_cases/Gaming_Analytics.md)       |               Real-time analyis of gaming data to enhance live gameplay & offer targeting               |      Beta :factory:       |
 
 ## Repository structure
 

--- a/pipelines/gaming_analytics/scripts/.gitignore
+++ b/pipelines/gaming_analytics/scripts/.gitignore
@@ -1,0 +1,1 @@
+00_set_environment.sh

--- a/terraform/AGENTS.md
+++ b/terraform/AGENTS.md
@@ -16,6 +16,7 @@ This directory contains Terraform infrastructure definitions for each solution g
 | `clickstream_analytics/` | Cloud Bigtable (Instance & Table), Pub/Sub Topic, BigQuery Dataset, Service Account | `pipelines/clickstream_analytics_java/` |
 | `iot_analytics/` | Cloud Bigtable (Instance & Table), BigQuery Dataset & Table, Pub/Sub Topic, Artifact Registry, Service Account | `pipelines/iot_analytics/` |
 | `log_replication_splunk/` | Pub/Sub Topics (`all-logs`, `deadletter-topic`), Cloud Logging Sink, Secret Manager (Splunk HEC token), Service Account, Optional Splunk Demo VM | `pipelines/log_replication_splunk/` |
+| `gaming_analytics/` | Pub/Sub Topics (`gaming-events`, `gaming-recommendations`, `gaming-analytics-errors`), Cloud Bigtable feature store (Instance & Table), BigQuery Dataset & Table, Artifact Registry, Service Account (`gaming-analytics-sa`) | `pipelines/gaming_analytics/` *(pipeline pending)* |
 
 ---
 

--- a/terraform/TERRAFORM_REVAMP_GUIDE.md
+++ b/terraform/TERRAFORM_REVAMP_GUIDE.md
@@ -328,6 +328,7 @@ pylint --rcfile ../pylintrc .
 | 6 | **`iot_analytics/`** *(Done)* | Cloud Bigtable (Instance & Table), BigQuery Dataset & Table, Pub/Sub Topics, Artifact Registry, Service Account | `iot-analytics-sa` | `pipelines/iot_analytics/` |
 | 7 | **`ml_ai/`** *(Done)* | Pub/Sub Topics (`messages`, `predictions`), Artifact Registry, GCS Bucket | `ml-ai-dataflow-sa` | `pipelines/ml_ai_python/` |
 | 8 | **`log_replication_splunk/`** *(Done)* | Pub/Sub Topic, Secret Manager (Splunk HEC token), Optional Splunk Demo VM | `splunk-replication-sa` | `pipelines/log_replication_splunk/` |
+| 9 | **`gaming_analytics/`** *(Done — built greenfield in the modern pattern)* | Pub/Sub Topics (`gaming-events`, `gaming-recommendations`, `gaming-analytics-errors`), Cloud Bigtable feature store, BigQuery Dataset & Table, Artifact Registry | `gaming-analytics-sa` | `pipelines/gaming_analytics/` *(pipeline pending)* |
 
 ---
 

--- a/terraform/gaming_analytics/README.md
+++ b/terraform/gaming_analytics/README.md
@@ -1,0 +1,127 @@
+# Gaming Analytics project deployment
+
+This directory contains the Terraform code to provision the application-level infrastructure required to run the Gaming Analytics solution guide on Google Cloud.
+
+These deployment scripts are part of the
+[Dataflow Gaming Analytics solution guide](../../use_cases/guides/gaming_analytics_dataflow_guide.pdf).
+
+The architecture ingests gameplay events from the gaming platform servers into Pub/Sub, enriches them with player features stored in Cloud Bigtable (Apache Beam `Enrichment` transform), scores them with `RunInference`, and writes the result to a Pub/Sub topic for immediate in-game activation plus a BigQuery dataset for analytics.
+
+## Bill of resources created by this script
+
+The scripts will create the following application-level resources:
+
+| Resource | Name | Description |
+| :--- | :---: | :--- |
+| **Pub/Sub topic (Input)** | `gaming-events` (configurable) | The input Pub/Sub topic for raw gameplay events published by the gaming servers. |
+| **Pub/Sub subscription (Input)** | `gaming-events-sub` | The subscription consumed by the Dataflow streaming pipeline. |
+| **Pub/Sub topic (Output)** | `gaming-recommendations` (configurable) | Buffers in-game recommendations to be sent back to the gaming platform. |
+| **Pub/Sub subscription (Output)** | `gaming-recommendations-sub` | Downstream subscription for the activation consumer. |
+| **Pub/Sub topic (Dead-letter)** | `gaming-analytics-errors` | Dead-letter topic for elements the pipeline cannot process. |
+| **Pub/Sub subscription (Dead-letter)** | `gaming-analytics-errors-sub` | Subscription used to inspect and reprocess failed elements. |
+| **Bigtable Instance** | `gaming-analytics` | Single-node Cloud Bigtable instance acting as the low-latency feature store. |
+| **Bigtable Table** | `player_features` | Feature table with column family `features`, used by the Beam `Enrichment` transform. |
+| **BigQuery Dataset** | `gaming_analytics` | Dataset holding the analytics output of the pipeline. |
+| **BigQuery Table** | `player_recommendations` | Scored gameplay events, day-partitioned on `event_timestamp` and clustered on `player_id`, `event_type`. |
+| **Artifact Registry** | `gaming-analytics-containers` | Docker repository hosting the custom Dataflow worker container image. |
+| **Service account** | `gaming-analytics-sa` (configurable) | Dedicated Dataflow worker identity with least-privilege roles (`roles/dataflow.worker`, `roles/monitoring.metricWriter`, `roles/storage.objectAdmin`, `roles/pubsub.editor`, `roles/bigquery.dataEditor`, `roles/bigquery.jobUser`), plus a table-scoped `roles/bigtable.reader` binding on `player_features`. |
+| **Custom IAM role** *(Vertex mode only)* | `gamingAnalyticsPredictor` | Grants only `aiplatform.endpoints.predict`, created when `inference_mode = "vertex"`. |
+| **GCS Bucket** *(Optional)* | `var.bucket_name` or `var.project_id` | Optional regional standard bucket for Dataflow temp/staging files (created when `create_bucket = true`). |
+
+This module deliberately does **not** create the project, VPC network, subnet, firewall rules or Cloud NAT. It deploys into an existing project and network (default, custom or Shared VPC).
+
+## Inference modes
+
+The guide supports two inference topologies. Both are covered by the `inference_mode` variable, which only changes the worker configuration exported to the pipeline and the associated IAM/API surface:
+
+| Mode | Worker machine type | Accelerator | Extra resources |
+| :--- | :---: | :---: | :--- |
+| `gpu` *(default)* | `g2-standard-4` | 1 x NVIDIA L4 | none |
+| `vertex` | `n1-standard-2` | none | `aiplatform.googleapis.com`, `gamingAnalyticsPredictor` custom role |
+
+> [!NOTE]
+> No Dataflow job and no Vertex AI endpoint are created by Terraform. In `vertex` mode you deploy the endpoint separately and grant it to the worker service account.
+
+## Configuration variables
+
+This deployment accepts the following configuration variables:
+
+| Variable | Type | Default | Description |
+| :--- | :---: | :---: | :--- |
+| `project_id` | `string` | *(Required)* | Existing GCP project ID where resources and IAM roles will be provisioned. |
+| `region` | `string` | *(Required)* | GCP region for Bigtable, BigQuery, Pub/Sub, Artifact Registry and Dataflow resources. |
+| `zone` | `string` | `"a"` | Zone suffix used for the Bigtable cluster and GPU worker placement (e.g. `a` yields `us-central1-a`). |
+| `subnetwork` | `string` | `null` | Optional subnetwork URL or path for Dataflow workers (e.g. `regions/europe-southwest1/subnetworks/dev-default` or a full Shared VPC URI). If omitted, the default network is used. |
+| `bucket_name` | `string` | `null` | Optional GCS bucket name for Dataflow temp/staging files. Defaults to `project_id` if not specified. |
+| `create_bucket` | `bool` | `false` | Set to `true` to provision a new GCS bucket, or `false` to reuse an existing one. |
+| `service_account_name` | `string` | `"gaming-analytics-sa"` | Name of the dedicated Dataflow worker service account to create. |
+| `inference_mode` | `string` | `"gpu"` | `gpu` for a local model on GPU workers, or `vertex` for a model behind a Vertex AI endpoint. |
+| `machine_type` | `string` | `null` | Overrides the worker machine type. Defaults to `g2-standard-4` (`gpu`) or `n1-standard-2` (`vertex`). |
+| `input_topic` | `string` | `"gaming-events"` | Name for the input Pub/Sub topic. |
+| `output_topic` | `string` | `"gaming-recommendations"` | Name for the output Pub/Sub topic. |
+| `destroy_all_resources` | `bool` | `true` | When `true`, allows deletion of the Bigtable instance and BigQuery dataset contents on `terraform destroy`. Set to `false` for production. |
+
+## How to deploy
+
+1. **Set configuration variables:**
+
+   Create a file named `terraform.tfvars` in this directory:
+
+   **Standard deployment (default network / same project):**
+   ```hcl
+   project_id            = "YOUR_PROJECT_ID"
+   region                = "us-central1"
+   destroy_all_resources = true
+   ```
+
+   **Shared VPC deployment (Dataflow in service project, network in host project):**
+   ```hcl
+   project_id            = "YOUR_PROJECT_ID"
+   region                = "europe-southwest1"
+   subnetwork            = "https://www.googleapis.com/compute/v1/projects/HOST_PROJECT_ID/regions/europe-southwest1/subnetworks/shared-dataflow-subnet"
+   bucket_name           = "YOUR_BUCKET_NAME"
+   create_bucket         = false
+   service_account_name  = "gaming-analytics-sa"
+   inference_mode        = "gpu"
+   destroy_all_resources = true
+   ```
+
+2. **Initialize Terraform:**
+   ```bash
+   terraform init
+   ```
+
+3. **Apply the configuration:**
+   ```bash
+   terraform plan -out=tfplan
+   terraform apply tfplan
+   ```
+
+4. **Access the deployed resources:**
+   Terraform generates `pipelines/gaming_analytics/scripts/00_set_environment.sh` with all required environment variables.
+
+> [!IMPORTANT]
+> If you deploy into an existing network with `--no_use_public_ips` workers, make sure Private Google Access is enabled on the subnet, that TCP ports `12345` and `12346` are allowed between workers, and that Cloud NAT is configured if the workers need internet access.
+
+## Scripts generation
+
+The Terraform code generates an environment configuration script with all variable values to be used by the pipeline:
+
+```bash
+source ../../pipelines/gaming_analytics/scripts/00_set_environment.sh
+```
+
+## How to remove
+
+To destroy all provisioned infrastructure:
+
+1. Cancel any active Dataflow streaming jobs first:
+   ```bash
+   gcloud dataflow jobs list --region=YOUR_REGION --status=active
+   gcloud dataflow jobs cancel JOB_ID --region=YOUR_REGION
+   ```
+
+2. Run `terraform destroy`:
+   ```bash
+   terraform destroy
+   ```

--- a/terraform/gaming_analytics/main.tf
+++ b/terraform/gaming_analytics/main.tf
@@ -1,0 +1,295 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+locals {
+  dataflow_service_account = var.service_account_name
+  bucket_name              = var.bucket_name != null ? var.bucket_name : var.project_id
+  subnetwork               = var.subnetwork != null ? trimspace(var.subnetwork) : ""
+
+  // Inference topology: local model on GPU workers, or remote Vertex AI endpoint.
+  use_gpu              = var.inference_mode == "gpu"
+  machine_type         = var.machine_type != null ? var.machine_type : (local.use_gpu ? "g2-standard-4" : "n1-standard-2")
+  accelerator          = local.use_gpu ? "worker_accelerator=type:nvidia-l4;count:1;install-nvidia-driver:5xx" : ""
+  worker_disk_size_gb  = local.use_gpu ? 200 : 50
+  max_dataflow_workers = 3
+
+  input_subscription  = "${var.input_topic}-sub"
+  output_subscription = "${var.output_topic}-sub"
+  error_topic         = "gaming-analytics-errors"
+  error_subscription  = "gaming-analytics-errors-sub"
+
+  bigtable_instance      = "gaming-analytics"
+  bigtable_table         = "player_features"
+  bigtable_column_family = "features"
+
+  bigquery_dataset = "gaming_analytics"
+  bigquery_table   = "player_recommendations"
+
+  base_services = [
+    "compute.googleapis.com",
+    "iam.googleapis.com",
+    "storage.googleapis.com",
+    "dataflow.googleapis.com",
+    "monitoring.googleapis.com",
+    "pubsub.googleapis.com",
+    "bigquery.googleapis.com",
+    "bigtable.googleapis.com",
+    "bigtableadmin.googleapis.com",
+    "artifactregistry.googleapis.com",
+    "cloudbuild.googleapis.com",
+  ]
+  services = local.use_gpu ? local.base_services : concat(local.base_services, ["aiplatform.googleapis.com"])
+}
+
+data "google_project" "project" {
+  project_id = var.project_id
+}
+
+// Declarative enablement of every API required by the application resources.
+resource "google_project_service" "application" {
+  for_each           = toset(local.services)
+  project            = var.project_id
+  service            = each.value
+  disable_on_destroy = false
+}
+
+// Artifact Registry repository hosting the custom Dataflow worker container
+// (GPU image with the local recommendation model, or a CPU image in Vertex mode).
+module "registry_docker" {
+  depends_on = [google_project_service.application]
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/artifact-registry?ref=v58.0.0"
+  project_id = var.project_id
+  location   = var.region
+  name       = "gaming-analytics-containers"
+  format     = { docker = { standard = {} } }
+  iam = {
+    "roles/artifactregistry.writer" = [
+      "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com",
+      "serviceAccount:${data.google_project.project.number}-compute@developer.gserviceaccount.com"
+    ]
+    "roles/artifactregistry.reader" = [
+      module.dataflow_sa.iam_email
+    ]
+  }
+  cleanup_policy_dry_run = false
+  cleanup_policies = {
+    keep-3-versions = {
+      action = "KEEP"
+      most_recent_versions = {
+        keep_count = 3
+      }
+    }
+  }
+}
+
+// Optional GCS bucket for Dataflow temp/staging files and model artifacts.
+module "buckets" {
+  depends_on    = [google_project_service.application]
+  count         = var.create_bucket ? 1 : 0
+  source        = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/gcs?ref=v58.0.0"
+  project_id    = var.project_id
+  name          = local.bucket_name
+  location      = var.region
+  storage_class = "STANDARD"
+  force_destroy = var.destroy_all_resources
+}
+
+// Input topic: raw gameplay events published by the gaming platform servers.
+module "input_topic" {
+  depends_on = [google_project_service.application]
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v58.0.0"
+  project_id = var.project_id
+  name       = var.input_topic
+  subscriptions = {
+    (local.input_subscription) = {}
+  }
+}
+
+// Output topic: buffers in-game recommendations sent back to the gaming servers.
+module "output_topic" {
+  depends_on = [google_project_service.application]
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v58.0.0"
+  project_id = var.project_id
+  name       = var.output_topic
+  subscriptions = {
+    (local.output_subscription) = {}
+  }
+}
+
+// Dead-letter topic for elements the pipeline cannot process.
+module "error_topic" {
+  depends_on = [google_project_service.application]
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/pubsub?ref=v58.0.0"
+  project_id = var.project_id
+  name       = local.error_topic
+  subscriptions = {
+    (local.error_subscription) = {}
+  }
+}
+
+// Cloud Bigtable feature store backing the Apache Beam Enrichment transform.
+module "feature_table" {
+  depends_on          = [google_project_service.application]
+  source              = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/bigtable-instance?ref=v58.0.0"
+  project_id          = var.project_id
+  name                = local.bigtable_instance
+  deletion_protection = !var.destroy_all_resources
+  clusters = {
+    cluster1 = {
+      zone      = "${var.region}-${var.zone}"
+      num_nodes = 1
+    }
+  }
+  tables = {
+    player_features = {
+      column_families = { features = {} }
+    }
+  }
+}
+
+// BigQuery dataset for the analytics side of the architecture.
+module "output_dataset" {
+  depends_on = [google_project_service.application]
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/bigquery-dataset?ref=v58.0.0"
+  project_id = var.project_id
+  id         = local.bigquery_dataset
+  location   = var.region
+  options    = { delete_contents_on_destroy = var.destroy_all_resources }
+}
+
+// Destination table with scored gameplay events, partitioned on event time.
+resource "google_bigquery_table" "player_recommendations" {
+  project             = var.project_id
+  dataset_id          = module.output_dataset.dataset_id
+  table_id            = local.bigquery_table
+  deletion_protection = !var.destroy_all_resources
+
+  time_partitioning {
+    type  = "DAY"
+    field = "event_timestamp"
+  }
+  clustering = ["player_id", "event_type"]
+
+  schema = jsonencode([
+    { name = "player_id", type = "STRING", mode = "REQUIRED" },
+    { name = "session_id", type = "STRING", mode = "NULLABLE" },
+    { name = "event_type", type = "STRING", mode = "NULLABLE" },
+    { name = "level", type = "INTEGER", mode = "NULLABLE" },
+    { name = "score", type = "INTEGER", mode = "NULLABLE" },
+    { name = "recommendation", type = "STRING", mode = "NULLABLE" },
+    { name = "recommendation_score", type = "FLOAT", mode = "NULLABLE" },
+    { name = "event_timestamp", type = "TIMESTAMP", mode = "REQUIRED" },
+    { name = "processing_timestamp", type = "TIMESTAMP", mode = "NULLABLE" }
+  ])
+}
+
+// Dedicated Dataflow worker service account with least-privilege project roles.
+module "dataflow_sa" {
+  depends_on = [google_project_service.application]
+  source     = "github.com/GoogleCloudPlatform/cloud-foundation-fabric//modules/iam-service-account?ref=v58.0.0"
+  project_id = var.project_id
+  name       = local.dataflow_service_account
+  iam_project_roles = {
+    (var.project_id) = [
+      "roles/dataflow.worker",
+      "roles/monitoring.metricWriter",
+      "roles/storage.objectAdmin",
+      "roles/pubsub.editor",
+      "roles/bigquery.dataEditor",
+      "roles/bigquery.jobUser",
+    ]
+  }
+}
+
+// Feature lookups are read-only and scoped to the enrichment table.
+resource "google_bigtable_table_iam_member" "worker_features" {
+  project       = var.project_id
+  instance_name = local.bigtable_instance
+  table         = local.bigtable_table
+  role          = "roles/bigtable.reader"
+  member        = module.dataflow_sa.iam_email
+  depends_on    = [module.feature_table]
+}
+
+// Vertex AI inference mode only: workers may call an endpoint, never train or deploy.
+resource "google_project_iam_custom_role" "predictor" {
+  count       = local.use_gpu ? 0 : 1
+  project     = var.project_id
+  role_id     = "gamingAnalyticsPredictor"
+  title       = "Gaming Analytics Predictor"
+  description = "Allows Dataflow workers to request online predictions from a Vertex AI endpoint."
+  permissions = ["aiplatform.endpoints.predict"]
+}
+
+resource "google_project_iam_member" "worker_predictor" {
+  count   = local.use_gpu ? 0 : 1
+  project = var.project_id
+  role    = google_project_iam_custom_role.predictor[0].id
+  member  = module.dataflow_sa.iam_email
+}
+
+// Additive permission on the existing local or Shared VPC subnet.
+resource "google_compute_subnetwork_iam_member" "dataflow_network_user" {
+  count      = local.subnetwork != "" ? 1 : 0
+  project    = try(regex("projects/([^/]+)/", local.subnetwork)[0], var.project_id)
+  region     = try(regex("regions/([^/]+)/", local.subnetwork)[0], var.region)
+  subnetwork = try(regex("subnetworks/([^/]+)", local.subnetwork)[0], local.subnetwork)
+  role       = "roles/compute.networkUser"
+  member     = module.dataflow_sa.iam_email
+  depends_on = [google_project_service.application]
+}
+
+// Script with variables to launch the Dataflow jobs
+resource "local_file" "variables_script" {
+  filename        = "${path.module}/../../pipelines/gaming_analytics/scripts/00_set_environment.sh"
+  file_permission = "0644"
+  content         = <<FILE
+# This file is generated by the Terraform code of this Solution Guide.
+# We recommend that you modify this file only through the Terraform deployment.
+export PROJECT=${var.project_id}
+export REGION=${var.region}
+export ZONE=${var.region}-${var.zone}
+export SUBNETWORK=${local.subnetwork}
+export NETWORK=$${SUBNETWORK}
+export TEMP_LOCATION=gs://${local.bucket_name}/tmp
+export SERVICE_ACCOUNT=${module.dataflow_sa.email}
+
+export DOCKER_REPOSITORY=${module.registry_docker.name}
+export IMAGE_NAME=dataflow-solutions-gaming-analytics
+export DOCKER_TAG=0.1
+export DOCKER_IMAGE=$REGION-docker.pkg.dev/$PROJECT/$DOCKER_REPOSITORY/$IMAGE_NAME
+export CONTAINER_URI=$DOCKER_IMAGE:$DOCKER_TAG
+
+export INFERENCE_MODE=${var.inference_mode}
+export MACHINE_TYPE=${local.machine_type}
+export ACCELERATOR_OPT=${local.accelerator}
+export DISK_SIZE_GB=${local.worker_disk_size_gb}
+export MAX_DATAFLOW_WORKERS=${local.max_dataflow_workers}
+
+export INPUT_TOPIC=projects/${var.project_id}/topics/${var.input_topic}
+export INPUT_SUBSCRIPTION=projects/${var.project_id}/subscriptions/${local.input_subscription}
+export OUTPUT_TOPIC=projects/${var.project_id}/topics/${var.output_topic}
+export OUTPUT_SUBSCRIPTION=projects/${var.project_id}/subscriptions/${local.output_subscription}
+export ERROR_TOPIC=projects/${var.project_id}/topics/${local.error_topic}
+export ERROR_SUBSCRIPTION=projects/${var.project_id}/subscriptions/${local.error_subscription}
+
+export BIGTABLE_INSTANCE=${local.bigtable_instance}
+export BIGTABLE_TABLE=${local.bigtable_table}
+export BIGTABLE_COLUMN_FAMILY=${local.bigtable_column_family}
+
+export BQ_DATASET=${module.output_dataset.dataset_id}
+export BQ_TABLE=${var.project_id}.${module.output_dataset.dataset_id}.${google_bigquery_table.player_recommendations.table_id}
+export BUCKET=${local.bucket_name}
+FILE
+}

--- a/terraform/gaming_analytics/providers.tf
+++ b/terraform/gaming_analytics/providers.tf
@@ -1,0 +1,16 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+provider "google" {}
+provider "google-beta" {}

--- a/terraform/gaming_analytics/tests/gaming_analytics.tftest.hcl
+++ b/terraform/gaming_analytics/tests/gaming_analytics.tftest.hcl
@@ -1,0 +1,100 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+mock_provider "google" {}
+mock_provider "google-beta" {}
+mock_provider "local" {}
+
+variables {
+  project_id = "gaming-test-project"
+  region     = "us-central1"
+}
+
+run "gpu_defaults" {
+  command = plan
+
+  assert {
+    condition     = local.machine_type == "g2-standard-4"
+    error_message = "GPU inference must default to a G2 worker."
+  }
+  assert {
+    condition     = local.accelerator != ""
+    error_message = "GPU inference must export an accelerator service option."
+  }
+  assert {
+    condition     = length(google_project_iam_custom_role.predictor) == 0
+    error_message = "The Vertex AI predict role must not exist in GPU mode."
+  }
+  assert {
+    condition     = google_bigtable_table_iam_member.worker_features.table == "player_features" && google_bigtable_table_iam_member.worker_features.role == "roles/bigtable.reader"
+    error_message = "Worker enrichment permissions must be table scoped and read only."
+  }
+  assert {
+    condition     = google_bigquery_table.player_recommendations.time_partitioning[0].field == "event_timestamp"
+    error_message = "Analytics partitioning must use event time, not processing time."
+  }
+  assert {
+    condition     = length(module.buckets) == 0
+    error_message = "Existing bucket reuse is the default."
+  }
+  assert {
+    condition     = length(google_compute_subnetwork_iam_member.dataflow_network_user) == 0
+    error_message = "No subnetwork IAM binding must be created when no subnetwork is configured."
+  }
+  assert {
+    condition     = !contains(local.services, "aiplatform.googleapis.com")
+    error_message = "Vertex AI must not be enabled when inference runs locally on GPUs."
+  }
+}
+
+run "vertex_mode" {
+  command = plan
+
+  variables {
+    inference_mode = "vertex"
+  }
+
+  assert {
+    condition     = local.machine_type == "n1-standard-2"
+    error_message = "Vertex AI inference must use CPU workers."
+  }
+  assert {
+    condition     = local.accelerator == ""
+    error_message = "Vertex AI inference must not attach GPUs to the workers."
+  }
+  assert {
+    condition     = google_project_iam_custom_role.predictor[0].permissions == toset(["aiplatform.endpoints.predict"])
+    error_message = "Workers may only predict, never train or deploy."
+  }
+  assert {
+    condition     = contains(local.services, "aiplatform.googleapis.com")
+    error_message = "Vertex AI must be enabled when inference is remote."
+  }
+}
+
+run "shared_vpc_subnetwork" {
+  command = plan
+
+  variables {
+    subnetwork = "https://www.googleapis.com/compute/v1/projects/host-project/regions/europe-southwest1/subnetworks/dataflow-subnet"
+  }
+
+  assert {
+    condition     = google_compute_subnetwork_iam_member.dataflow_network_user[0].project == "host-project"
+    error_message = "The subnetwork IAM binding must target the Shared VPC host project."
+  }
+  assert {
+    condition     = google_compute_subnetwork_iam_member.dataflow_network_user[0].subnetwork == "dataflow-subnet"
+    error_message = "The subnetwork name must be resolved from the full URI."
+  }
+}

--- a/terraform/gaming_analytics/variables.tf
+++ b/terraform/gaming_analytics/variables.tf
@@ -1,0 +1,88 @@
+#  Copyright 2026 Google LLC
+#
+#  Licensed under the Apache License, Version 2.0 (the "License");
+#  you may not use this file except in compliance with the License.
+#  You may obtain a copy of the License at
+#
+#      https://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+#  limitations under the License.
+
+variable "project_id" {
+  description = "Project ID of the existing GCP project where resources will be provisioned."
+  type        = string
+}
+
+variable "region" {
+  description = "The GCP region for application resources and Dataflow jobs."
+  type        = string
+}
+
+variable "zone" {
+  description = "Zone suffix (e.g. 'a') used for the Bigtable cluster and for GPU worker placement."
+  type        = string
+  default     = "a"
+}
+
+variable "subnetwork" {
+  description = "Optional subnetwork URL or path for Dataflow workers (e.g. regions/europe-southwest1/subnetworks/dev-default or full URI). If omitted, the default network is used."
+  type        = string
+  default     = null
+}
+
+variable "bucket_name" {
+  description = "Optional GCS bucket name for Dataflow temp/staging files. Defaults to project_id if not specified."
+  type        = string
+  default     = null
+}
+
+variable "create_bucket" {
+  description = "Whether to create a new GCS bucket for temp/staging files. Set to false if using an existing bucket."
+  type        = bool
+  default     = false
+}
+
+variable "service_account_name" {
+  description = "Name of the dedicated Dataflow worker service account to create."
+  type        = string
+  default     = "gaming-analytics-sa"
+}
+
+variable "inference_mode" {
+  description = "Where the recommendation model runs: 'gpu' for a local model on GPU workers, or 'vertex' for a model deployed behind a Vertex AI endpoint (CPU workers)."
+  type        = string
+  default     = "gpu"
+
+  validation {
+    condition     = contains(["gpu", "vertex"], var.inference_mode)
+    error_message = "inference_mode must be either 'gpu' or 'vertex'."
+  }
+}
+
+variable "machine_type" {
+  description = "Dataflow worker machine type. Defaults to g2-standard-4 in 'gpu' mode and n1-standard-2 in 'vertex' mode when left null."
+  type        = string
+  default     = null
+}
+
+variable "input_topic" {
+  description = "Name for the input Pub/Sub topic carrying raw gameplay events."
+  type        = string
+  default     = "gaming-events"
+}
+
+variable "output_topic" {
+  description = "Name for the output Pub/Sub topic buffering in-game recommendations."
+  type        = string
+  default     = "gaming-recommendations"
+}
+
+variable "destroy_all_resources" {
+  description = "Destroy all resources when calling tf destroy. Use false for production deployments. For test environments, set to true to remove all resources."
+  type        = bool
+  default     = true
+}

--- a/use_cases/Gaming_Analytics.md
+++ b/use_cases/Gaming_Analytics.md
@@ -1,0 +1,81 @@
+# Real-Time Gaming Analytics
+
+Real-time gaming analytics refers to collecting, processing, and analyzing player data as it is generated during gameplay. This provides immediate insights into player behavior, game performance, and overall player experience. Incorporating real-time feedback into a game enriches both single-player and multi-player experiences and improves revenue per user when integrated with an existing application architecture.
+
+While this solution is geared towards one single industry (gaming) on the surface, gamification is now pervasive across many verticals. The same principles apply to education, healthcare, retail and e-commerce.
+
+This reference architecture demonstrates how to ingest gameplay events from the gaming platform servers via **Cloud Pub/Sub**, hydrate them with player features held in **Cloud Bigtable** using Apache Beam's turnkey `Enrichment` transform, score them with `RunInference` (either a local model on GPU workers or a model deployed behind a **Vertex AI** endpoint), publish recommendations back to a **Pub/Sub** topic for immediate in-game activation, and persist analytical records to **BigQuery**.
+
+## Documentation
+
+- [Gaming Analytics Solution Guide & Architecture (PDF)](./guides/gaming_analytics_dataflow_guide.pdf)
+
+## Architecture
+
+```mermaid
+flowchart LR
+  GS["Gaming platform servers"] -->|gameplay events| IT["Pub/Sub<br/>gaming-events"]
+  IT --> DF["Dataflow: in-game recommender<br/>Enrichment + RunInference"]
+  BT[("Cloud Bigtable<br/>player_features")] -.->|feature lookup| DF
+  DF -->|recommendations| OT["Pub/Sub<br/>gaming-recommendations"]
+  DF -->|analytical records| BQ[("BigQuery<br/>gaming_analytics")]
+  DF -->|unprocessable elements| DL["Pub/Sub<br/>gaming-analytics-errors"]
+  OT --> GS
+```
+
+The essential property of this architecture is that **Pub/Sub is used as the output**, enabling continuous injection of recommendations back into the game. Player engagement depends on the time-to-activation.
+
+The analytics side can be part of the same pipeline or, as recommended in the guide, deployed as a separate pipeline reading from the output topic, to avoid performance interference between the in-game activation path and the analytics path.
+
+## Assets included in this repository
+
+- [Terraform code to deploy infrastructure for Gaming Analytics](../terraform/gaming_analytics/): Provisions the input, output and dead-letter Pub/Sub topics and subscriptions, a Cloud Bigtable feature store, a BigQuery dataset with an event-time partitioned `player_recommendations` table, an Artifact Registry repository for the custom worker container, an optional GCS bucket, and a dedicated least-privilege Dataflow worker service account.
+- Sample streaming pipeline: *not available yet*. The Terraform module already generates `pipelines/gaming_analytics/scripts/00_set_environment.sh` with every value a pipeline needs (topics, subscriptions, Bigtable coordinates, BigQuery table, container URI, worker machine type and accelerator options).
+
+## Design considerations
+
+| Step | Description |
+| :--- | :--- |
+| **Real-time input and output (Extract)** | The architecture assumes Cloud Pub/Sub or Kafka for receiving data from the gaming servers. The Terraform module provisions Pub/Sub. Setting up the real-time export from the gaming platform into Pub/Sub is out of scope. |
+| **Enrichment (Transform)** | Upstream sources are assumed to only carry ids; every other feature required for inference lives in Cloud Bigtable (or Vertex AI Feature Store), both of which are supported by the turnkey Apache Beam [`Enrichment`](https://beam.apache.org/documentation/transforms/python/elementwise/enrichment/) transform. For any other database, use the [Web APIs I/O connector](https://beam.apache.org/documentation/io/built-in/webapis/). |
+| **Inference (Transform)** | `RunInference` works both with a local model leveraging a GPU (lowest prediction latency) and with external models deployed in a Vertex AI endpoint, as a HuggingFace pipeline, or as a GenAI API. The Terraform module exposes this choice through the `inference_mode` variable. |
+| **Output (Load)** | Predictions are written to a Pub/Sub topic that buffers activations before they are sent back to the gaming platform. For marketing platforms without a specific connector, use the Web APIs I/O connector; Google Ads has a dedicated Beam connector. |
+| **Unprocessable data** | Failed elements are routed with branching outputs to a dead-letter Pub/Sub topic instead of being dropped, for later inspection and reprocessing. |
+
+## Technical benefits
+
+Dataflow is the premier platform for building real-time gaming analytics and in-game activation applications:
+
+- **Streaming AI**:
+  - Enhance the player experience with streaming predictions. Call models from your pipeline with `RunInference`, either locally on GPU workers or through a Vertex AI endpoint, and deliver personalized gameplay in real time.
+- **Ultra-low-latency feature lookups with Cloud Bigtable**:
+  - Cloud Bigtable delivers single-digit millisecond row lookups at petabyte scale, letting workers hydrate id-only events with player features without bottlenecking throughput.
+- **Horizontal autoscaling**:
+  - Gaming workloads oscillate over the course of a day, a week, or a launch cycle. Dataflow's horizontal autoscaling avoids overprovisioning for a big release and underprovisioning during quiet periods.
+- **Event time model**:
+  - Apache Beam provides rich semantics for analyzing on event time rather than processing time, preserving analytical accuracy even when players disconnect mid-session.
+- **Deep I/O integration**:
+  - Read performance from streaming systems such as Pub/Sub and Kafka scales effortlessly beyond 10 GB/s.
+- **Global availability**:
+  - Dataflow's worldwide availability, backed by Google's network infrastructure, lets stream processing respond gracefully to traffic spikes wherever they occur.
+
+## Customer stories
+
+- **Nintendo** deployed Pub/Sub, Dataflow, and BigQuery to collect log data from Super Mario Run, which reached 40 million downloads in four days without any major issues.
+- **Niantic**'s data science teams worked with BigQuery, Bigtable, Dataflow, and Pub/Sub to support the launch of Pokémon GO, scaling to close to a million transactions per second in a matter of minutes.
+- **King / Activision Blizzard** migrated from on-premises systems to Dataflow to ingest data and support its massive data archive.
+
+## How to deploy
+
+Follow the [Terraform module README](../terraform/gaming_analytics/README.md) for the full instructions:
+
+```bash
+cd terraform/gaming_analytics
+# create terraform.tfvars with at least project_id and region
+terraform init
+terraform plan -out=tfplan
+terraform apply tfplan
+source ../../pipelines/gaming_analytics/scripts/00_set_environment.sh
+```
+
+To tear the deployment down, cancel any active Dataflow streaming job first, then run `terraform destroy`.


### PR DESCRIPTION
## What

The Gaming Analytics guide is listed in the repository README and ships as a design PDF, but it had no Terraform code, no pipeline, and its documentation link pointed at a file that never existed.

This PR adds the missing infrastructure module `terraform/gaming_analytics/`, plus the use case document.

## Architecture

```
Gaming servers → Pub/Sub gaming-events → Dataflow (Enrichment + RunInference) → Pub/Sub gaming-recommendations → Gaming servers
                                                  ↑ Bigtable player_features      ↓ BigQuery gaming_analytics
                                                                                  ↓ Pub/Sub gaming-analytics-errors
```

## Design notes

The module is written directly in the lightweight pattern from `TERRAFORM_REVAMP_GUIDE.md`. It deploys into an existing project and network and creates no project, VPC, firewall rules or Cloud NAT.

Resources:

- Pub/Sub input, output and dead-letter topics with subscriptions. Pub/Sub as the **output** is the essential property of this architecture: player engagement depends on time-to-activation.
- Cloud Bigtable feature store (`player_features`), backing the turnkey Apache Beam `Enrichment` transform.
- BigQuery dataset with a `player_recommendations` table, day-partitioned on **event time** and clustered on `player_id`, `event_type`.
- Artifact Registry repository for the custom Dataflow worker container.
- Dedicated least-privilege worker service account. Bigtable access is a **table-scoped** `roles/bigtable.reader` binding rather than a project-wide role.
- Optional GCS bucket, and an additive `roles/compute.networkUser` binding that resolves both local subnets and full Shared VPC URIs.

### Inference modes

The guide describes two inference topologies; both are supported through a single `inference_mode` variable.

| | `gpu` (default) | `vertex` |
| :--- | :--- | :--- |
| Machine type | `g2-standard-4` | `n1-standard-2` |
| Accelerator | 1 × NVIDIA L4 | none |
| `aiplatform.googleapis.com` | not enabled | enabled |
| `gamingAnalyticsPredictor` role | not created | created, `aiplatform.endpoints.predict` only |

In `vertex` mode the worker can only predict, never train or deploy.

## Testing

```
terraform fmt -check -diff     → clean
terraform init -backend=false  → ok
terraform validate             → Success! The configuration is valid.
terraform test                 → 3 passed, 0 failed
```

The new `tests/gaming_analytics.tftest.hcl` uses mocked providers and asserts: GPU defaults and accelerator export, absence of the Vertex role in GPU mode, table-scoped read-only Bigtable IAM, event-time partitioning, bucket reuse as the default, no subnet IAM binding when no subnetwork is configured, CPU + predict-only role in `vertex` mode, and host-project/subnet-name resolution from a full Shared VPC URI.

> [!IMPORTANT]
> Per `CONTRIBUTING.md`, this has **not yet been applied against a live Google Cloud project**. That verification is pending and should happen before merge.

## Follow-up work

- The Beam pipeline itself. The module already generates `pipelines/gaming_analytics/scripts/00_set_environment.sh` with every value such a pipeline needs, and this PR adds only the `.gitignore` placeholder for that directory.
- The docs cite Cloud Foundation Fabric `v56.2.0` / `v57.0.0` in `terraform/AGENTS.md` and `TERRAFORM_REVAMP_GUIDE.md`, while all code (including this module) pins `v58.0.0`. Left untouched here to keep the diff focused.
